### PR TITLE
Update Build Environment and CMake Configurations for GCC and QNX Targets

### DIFF
--- a/CMake/CMakeConfig/gcc11_linux_aarch64_debug.cmake
+++ b/CMake/CMakeConfig/gcc11_linux_aarch64_debug.cmake
@@ -1,0 +1,100 @@
+#[=======================================================================
+# OpenAA: Open Source Adaptive AUTOSAR Project
+# Author: Sherif Mohamed
+#
+# File description:
+# -----------------
+# CMake initial-cache file for GCC 11 on Linux x86_64.
+# This file sets essential CMake variables and compiler/linker flags
+# to streamline the build process for Linux targets.
+#=======================================================================]
+
+#[=======================================================================[
+.rst:
+gcc11_linux_x86_64
+-------------------
+CMake initial cache file for GCC 11 on Linux x86_64.
+
+All variables can be set as initial cache variables and passed as a file to CMake:
+
+.. code-block:: cmake
+
+    # Create an initial cache file (gcc11_linux_x86_64.cmake) and define in there:
+    set(CMAKE_PREFIX_PATH "/usr/local/gcc-11" CACHE STRING "")
+    set(CMAKE_TOOLCHAIN_FILE "/path/to/toolchain/gcc11_linux_x86_64.cmake" CACHE PATH "")
+
+.. code-block:: shell-session
+
+    $ cmake -C CMake/CMakeConfig/gcc11_linux_x86_64.cmake -S <project-root> -B <build-dir>
+
+#]=======================================================================]
+
+#[=======================================================================[
+  CMake Specific Project Settings
+#]=======================================================================]
+
+#=======================================================================
+# Library Building Preferences
+#=======================================================================
+#
+# Control whether to build shared or static libraries.
+# Set to ON to build shared libraries, OFF to build static libraries.
+#
+# Recommended: OFF for static libraries to simplify deployment.
+#=======================================================================
+
+#=======================================================================
+message(STATUS "Using gcc11_linux_x86_64_debug.cmake for initial cache setup.")
+
+#=======================================================================
+# Library Building Preferences
+#=======================================================================
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")
+
+#=======================================================================
+# Compiler Configuration for C
+#=======================================================================
+set(CMAKE_C_FLAGS_INIT "-Wall -Wextra -Wconversion -pedantic -Wshadow -Wdouble-promotion -Wformat=2 \
+-Wnull-dereference -g" CACHE STRING "Initial C Compiler Flags for Debug Build")
+
+set(CMAKE_C_FLAGS_DEBUG_INIT "-O0 -g3" CACHE STRING "C Compiler Flags for Debug Build")
+
+#=======================================================================
+# Compiler Configuration for C++
+#=======================================================================
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wnon-virtual-dtor -Wconversion -Wold-style-cast -pedantic \
+-Wshadow -Wno-error=deprecated-declarations -Wdouble-promotion -Wformat=2 -g" CACHE STRING "Initial C++ Compiler Flags for Debug Build")
+
+set(CMAKE_CXX_FLAGS_DEBUG_INIT "-O0 -g3" CACHE STRING "C++ Compiler Flags for Debug Build")
+
+#=======================================================================
+# Linker Flags Configuration
+#=======================================================================
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-g" CACHE STRING "Initial Executable Linker Flags for Debug")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "-g" CACHE STRING "Initial Shared Library Linker Flags for Debug")
+
+#=======================================================================
+# Build-Type Configuration
+#=======================================================================
+set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build type (Debug, Release, etc.)")
+
+#=======================================================================
+# Additional Debugging Features
+#=======================================================================
+set(CMAKE_C_FLAGS_ALSAN_INIT "-fsanitize=address -fno-omit-frame-pointer" CACHE STRING "Address Sanitizer Flags for C")
+set(CMAKE_CXX_FLAGS_ALSAN_INIT "-fsanitize=address -fno-omit-frame-pointer" CACHE STRING "Address Sanitizer Flags for C++")
+
+set(CMAKE_C_FLAGS_TSAN_INIT "-fsanitize=thread" CACHE STRING "Thread Sanitizer Flags for C")
+set(CMAKE_CXX_FLAGS_TSAN_INIT "-fsanitize=thread" CACHE STRING "Thread Sanitizer Flags for C++")
+
+set(CMAKE_C_FLAGS_UBSAN_INIT "-fsanitize=undefined" CACHE STRING "Undefined Behavior Sanitizer Flags for C")
+set(CMAKE_CXX_FLAGS_UBSAN_INIT "-fsanitize=undefined" CACHE STRING "Undefined Behavior Sanitizer Flags for C++")
+
+#=======================================================================
+# Notes for Debugging
+#=======================================================================
+# 1. Debug builds include extensive debugging information with `-g3`.
+# 2. Address, thread, and undefined behavior sanitizers are enabled to catch runtime issues.
+# 3. Warnings are set to maximum to enforce ISO compliance and detect potential issues.
+# 4. Optimizations are disabled (`-O0`) to facilitate debugging.
+#=======================================================================

--- a/CMake/CMakeConfig/gcc11_linux_aarch64_release.cmake
+++ b/CMake/CMakeConfig/gcc11_linux_aarch64_release.cmake
@@ -1,0 +1,168 @@
+#[=======================================================================
+# OpenAA: Open Source Adaptive AUTOSAR Project
+# Author: Sherif Mohamed
+#
+# This software is copyright protected and proprietary to Your
+# Company. You are granted only those rights as set out in the
+# license conditions. All other rights remain with Your Company.
+#
+# File description:
+# -----------------
+# CMake initial-cache file for GCC 11 on Linux aarch64.
+# This file sets essential CMake variables and compiler/linker flags
+# to streamline the build process for Linux targets.
+#=======================================================================]
+
+#[=======================================================================[
+.rst:
+gcc11_linux_aarch64
+-------------------
+CMake initial cache file for GCC 11 on Linux aarch64.
+
+All variables can be set as initial cache variables and passed as a file to CMake:
+
+.. code-block:: cmake
+
+    # Create an initial cache file (gcc11_linux_aarch64.cmake) and define in there:
+    set(CMAKE_PREFIX_PATH "/usr/local/gcc-11" CACHE STRING "")
+    set(CMAKE_TOOLCHAIN_FILE "/path/to/toolchain/gcc11_linux_aarch64.cmake" CACHE PATH "")
+
+.. code-block:: shell-session
+
+    $ cmake -C CMake/CMakeConfig/gcc11_linux_aarch64.cmake -S <project-root> -B <build-dir>
+
+#]=======================================================================]
+
+#[=======================================================================[
+  CMake Specific Project Settings
+#]=======================================================================]
+
+#=======================================================================
+# Library Building Preferences
+#=======================================================================
+#
+# Control whether to build shared or static libraries.
+# Set to ON to build shared libraries, OFF to build static libraries.
+#
+# Recommended: OFF for static libraries to simplify deployment.
+#=======================================================================
+message(STATUS "Using gcc11_linux_aarch64_release.cmake for initial cache setup.")
+
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")
+
+#=======================================================================
+# Compiler Configuration for C
+#=======================================================================
+#
+# These flags are used by the C compiler during respective build types.
+# Adjust them according to your project's requirements and target environment.
+#
+# Flags:
+#   -Wall, -Wextra: Enable most compiler warnings.
+#   -Wconversion: Warn for implicit type conversions that may alter a value.
+#   -pedantic: Enforce strict ISO compliance.
+#   -Wshadow: Warn when a variable shadows another variable.
+#=======================================================================
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wnon-virtual-dtor -Wconversion -Wold-style-cast -pedantic -Wshadow -Wno-error=deprecated-declarations -v" CACHE STRING "Initial C++ Compiler Flags")
+
+#-----------------------------------------------------------------------
+# Build-Type Specific C Flags
+#-----------------------------------------------------------------------
+# Flags for Debug build: No optimization, include debug symbols.
+set(CMAKE_C_FLAGS_DEBUG_INIT "-O0 -g" CACHE STRING "C Compiler Flags for Debug")
+
+# Flags for MinSizeRel build: Optimize for size, define NDEBUG.
+set(CMAKE_C_FLAGS_MINSIZEREL_INIT "-Os -DNDEBUG" CACHE STRING "C Compiler Flags for MinSizeRel")
+
+# Flags for Release build: Optimize for speed, define NDEBUG.
+set(CMAKE_C_FLAGS_RELEASE_INIT "-O3 -DNDEBUG" CACHE STRING "C Compiler Flags for Release")
+
+# Flags for RelWithDebInfo build: Optimize with debug symbols.
+set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "-O2 -g -DNDEBUG" CACHE STRING "C Compiler Flags for RelWithDebInfo")
+
+# Additional sanitizer flags for special build types.
+set(CMAKE_C_FLAGS_ALSAN_INIT "-fsanitize=address -fno-omit-frame-pointer" CACHE STRING "C Compiler Flags for Address Sanitizer")
+set(CMAKE_C_FLAGS_TSAN_INIT "-fsanitize=thread" CACHE STRING "C Compiler Flags for Thread Sanitizer")
+set(CMAKE_C_FLAGS_UBSAN_INIT "-fsanitize=undefined" CACHE STRING "C Compiler Flags for Undefined Behavior Sanitizer")
+
+#=======================================================================
+# Compiler Configuration for C++
+#=======================================================================
+#
+# These flags are used by the C++ compiler during respective build types.
+# Adjust them according to your project's requirements and target environment.
+#
+# Flags:
+#   -Wall, -Wextra: Enable most compiler warnings.
+#   -Wnon-virtual-dtor: Warn if a class with virtual functions has a non-virtual destructor.
+#   -Wconversion: Warn for implicit type conversions that may alter a value.
+#   -Wold-style-cast: Warn about C-style casts.
+#   -pedantic: Enforce strict ISO compliance.
+#   -Wshadow: Warn when a variable shadows another variable.
+#=======================================================================
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wnon-virtual-dtor -Wconversion -Wold-style-cast -pedantic -Wshadow" CACHE STRING "Initial C++ Compiler Flags")
+
+#-----------------------------------------------------------------------
+# Build-Type Specific C++ Flags
+#-----------------------------------------------------------------------
+# Flags for Debug build: No optimization, include debug symbols.
+set(CMAKE_CXX_FLAGS_DEBUG_INIT "-O0 -g" CACHE STRING "C++ Compiler Flags for Debug")
+
+# Flags for MinSizeRel build: Optimize for size, define NDEBUG.
+set(CMAKE_CXX_FLAGS_MINSIZEREL_INIT "-Os -DNDEBUG" CACHE STRING "C++ Compiler Flags for MinSizeRel")
+
+# Flags for Release build: Optimize for speed, define NDEBUG.
+set(CMAKE_CXX_FLAGS_RELEASE_INIT "-O3 -DNDEBUG" CACHE STRING "C++ Compiler Flags for Release")
+
+# Flags for RelWithDebInfo build: Optimize with debug symbols.
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "-O2 -g -DNDEBUG" CACHE STRING "C++ Compiler Flags for RelWithDebInfo")
+
+# Additional sanitizer flags for special build types.
+set(CMAKE_CXX_FLAGS_ALSAN_INIT "-fsanitize=address -fno-omit-frame-pointer" CACHE STRING "C++ Compiler Flags for Address Sanitizer")
+set(CMAKE_CXX_FLAGS_TSAN_INIT "-fsanitize=thread" CACHE STRING "C++ Compiler Flags for Thread Sanitizer")
+set(CMAKE_CXX_FLAGS_UBSAN_INIT "-fsanitize=undefined" CACHE STRING "C++ Compiler Flags for Undefined Behavior Sanitizer")
+set(CMAKE_CXX_FLAGS_RELEASEWITHO2_INIT "-O2 -DNDEBUG" CACHE STRING "C++ Compiler Flags for ReleaseWithO2")
+
+#=======================================================================
+# Linker Flags Configuration
+#=======================================================================
+#
+# These flags are used by the linker during respective build types.
+# Adjust them based on your project's requirements and target environment.
+#=======================================================================
+
+#=======================================================================
+# Executable Linker Flags
+#=======================================================================
+#
+# Initial flags for the executable linker applicable to all build types.
+#=======================================================================
+set(CMAKE_EXE_LINKER_FLAGS_INIT "" CACHE STRING "Initial Executable Linker Flags")
+
+#-----------------------------------------------------------------------
+# Build-Type Specific Executable Linker Flags
+#-----------------------------------------------------------------------
+# Flags for Debug build: Include debug symbols.
+set(CMAKE_EXE_LINKER_FLAGS_DEBUG_INIT "-g" CACHE STRING "Executable Linker Flags for Debug")
+
+# Flags for MinSizeRel build: Strip symbols to reduce size.
+set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL_INIT "-s" CACHE STRING "Executable Linker Flags for MinSizeRel")
+
+# Flags for Release build: No additional flags.
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE_INIT "" CACHE STRING "Executable Linker Flags for Release")
+
+# Flags for RelWithDebInfo build: Include debug symbols.
+set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO_INIT "-g" CACHE STRING "Executable Linker Flags for RelWithDebInfo")
+
+#=======================================================================
+# Additional CMake Settings
+#=======================================================================
+#
+# Add any additional CMake variables and configurations below as needed.
+# This section is reserved for any project-specific settings that do not
+# fit into the categories above.
+#
+# Example:
+# set(SOME_PROJECT_VARIABLE "value" CACHE STRING "Description of the variable")
+#
+#=======================================================================

--- a/CMake/CMakeConfig/gcc11_linux_x86_64_debug.cmake
+++ b/CMake/CMakeConfig/gcc11_linux_x86_64_debug.cmake
@@ -2,36 +2,49 @@
 # OpenAA: Open Source Adaptive AUTOSAR Project
 # Author: Sherif Mohamed
 #
-# This software is copyright protected and proprietary to Your
-# Company. You are granted only those rights as set out in the
-# license conditions. All other rights remain with Your Company.
-#
 # File description:
 # -----------------
-# CMake initial-cache file for OpenAA - QNX 8.0 x86_64 using QCC-12.
-# Debug build configuration with enhanced warnings and ISO compliance.
+# CMake initial-cache file for GCC 11 on Linux x86_64.
+# This file sets essential CMake variables and compiler/linker flags
+# to streamline the build process for Linux targets.
 #=======================================================================]
 
 #[=======================================================================[
 .rst:
-QNX800_x86_64_QCC12_DEBUG
----------------------------
-CMake initial cache file for QNX 8.0 x86_64 debug builds using QCC-12.
+gcc11_linux_x86_64
+-------------------
+CMake initial cache file for GCC 11 on Linux x86_64.
 
-This file sets essential CMake variables and compiler/linker flags to support
-debugging, such as including debug symbols, disabling optimizations, and enabling
-maximum warnings for ISO compliance.
+All variables can be set as initial cache variables and passed as a file to CMake:
+
+.. code-block:: cmake
+
+    # Create an initial cache file (gcc11_linux_x86_64.cmake) and define in there:
+    set(CMAKE_PREFIX_PATH "/usr/local/gcc-11" CACHE STRING "")
+    set(CMAKE_TOOLCHAIN_FILE "/path/to/toolchain/gcc11_linux_x86_64.cmake" CACHE PATH "")
 
 .. code-block:: shell-session
 
-    # QNX dev kit can only be used with bash!
-    $ bash -i
-    $ source /opt/qnx800/qnxsdp-env.sh
-    $ cmake -C CMake/CMakeConfig/qcc12_qnx800_x86_64_debug.cmake -S <project-root> -B <build-dir>
+    $ cmake -C CMake/CMakeConfig/gcc11_linux_x86_64.cmake -S <project-root> -B <build-dir>
 
 #]=======================================================================]
 
-message(STATUS "Using qcc12_qnx800_x86_64_debug.cmake for debug build configuration.")
+#[=======================================================================[
+  CMake Specific Project Settings
+#]=======================================================================]
+
+#=======================================================================
+# Library Building Preferences
+#=======================================================================
+#
+# Control whether to build shared or static libraries.
+# Set to ON to build shared libraries, OFF to build static libraries.
+#
+# Recommended: OFF for static libraries to simplify deployment.
+#=======================================================================
+
+#=======================================================================
+message(STATUS "Using gcc11_linux_x86_64_debug.cmake for initial cache setup.")
 
 #=======================================================================
 # Library Building Preferences
@@ -42,7 +55,7 @@ set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")
 # Compiler Configuration for C
 #=======================================================================
 set(CMAKE_C_FLAGS_INIT "-Wall -Wextra -Wconversion -pedantic -Wshadow -Wdouble-promotion -Wformat=2 \
--Wnull-dereference -D_QNX_SOURCE -g" CACHE STRING "Initial C Compiler Flags for Debug Build")
+-Wnull-dereference -g" CACHE STRING "Initial C Compiler Flags for Debug Build")
 
 set(CMAKE_C_FLAGS_DEBUG_INIT "-O0 -g3" CACHE STRING "C Compiler Flags for Debug Build")
 
@@ -50,7 +63,7 @@ set(CMAKE_C_FLAGS_DEBUG_INIT "-O0 -g3" CACHE STRING "C Compiler Flags for Debug 
 # Compiler Configuration for C++
 #=======================================================================
 set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wnon-virtual-dtor -Wconversion -Wold-style-cast -pedantic \
--Wshadow -Wno-error=deprecated-declarations -Wdouble-promotion -Wformat=2 -D_QNX_SOURCE -g" CACHE STRING "Initial C++ Compiler Flags for Debug Build")
+-Wshadow -Wno-error=deprecated-declarations -Wdouble-promotion -Wformat=2 -g" CACHE STRING "Initial C++ Compiler Flags for Debug Build")
 
 set(CMAKE_CXX_FLAGS_DEBUG_INIT "-O0 -g3" CACHE STRING "C++ Compiler Flags for Debug Build")
 

--- a/CMake/CMakeConfig/gcc11_linux_x86_64_release.cmake
+++ b/CMake/CMakeConfig/gcc11_linux_x86_64_release.cmake
@@ -1,6 +1,6 @@
-#[=======================================================================[
-# Copyright (c) 2024 by Your Company.
-# All rights reserved.
+#[=======================================================================
+# OpenAA: Open Source Adaptive AUTOSAR Project
+# Author: Sherif Mohamed
 #
 # This software is copyright protected and proprietary to Your
 # Company. You are granted only those rights as set out in the
@@ -46,7 +46,7 @@ All variables can be set as initial cache variables and passed as a file to CMak
 #
 # Recommended: OFF for static libraries to simplify deployment.
 #=======================================================================
-message(STATUS "Using gcc11_linux_x86_64.cmake for initial cache setup.")
+message(STATUS "Using gcc11_linux_x86_64_release.cmake for initial cache setup.")
 
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")
 
@@ -63,7 +63,7 @@ set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")
 #   -pedantic: Enforce strict ISO compliance.
 #   -Wshadow: Warn when a variable shadows another variable.
 #=======================================================================
-set(CMAKE_C_FLAGS_INIT "-Wall -Wextra -Wconversion -pedantic -Wshadow" CACHE STRING "Initial C Compiler Flags")
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wnon-virtual-dtor -Wconversion -Wold-style-cast -pedantic -Wshadow -Wno-error=deprecated-declarations -v" CACHE STRING "Initial C++ Compiler Flags")
 
 #-----------------------------------------------------------------------
 # Build-Type Specific C Flags
@@ -121,6 +121,7 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "-O2 -g -DNDEBUG" CACHE STRING "C++ Comp
 set(CMAKE_CXX_FLAGS_ALSAN_INIT "-fsanitize=address -fno-omit-frame-pointer" CACHE STRING "C++ Compiler Flags for Address Sanitizer")
 set(CMAKE_CXX_FLAGS_TSAN_INIT "-fsanitize=thread" CACHE STRING "C++ Compiler Flags for Thread Sanitizer")
 set(CMAKE_CXX_FLAGS_UBSAN_INIT "-fsanitize=undefined" CACHE STRING "C++ Compiler Flags for Undefined Behavior Sanitizer")
+set(CMAKE_CXX_FLAGS_RELEASEWITHO2_INIT "-O2 -DNDEBUG" CACHE STRING "C++ Compiler Flags for ReleaseWithO2")
 
 #=======================================================================
 # Linker Flags Configuration

--- a/CMake/CMakeConfig/gcc11_linux_x86_64_release.cmake
+++ b/CMake/CMakeConfig/gcc11_linux_x86_64_release.cmake
@@ -1,0 +1,167 @@
+#[=======================================================================[
+# Copyright (c) 2024 by Your Company.
+# All rights reserved.
+#
+# This software is copyright protected and proprietary to Your
+# Company. You are granted only those rights as set out in the
+# license conditions. All other rights remain with Your Company.
+#
+# File description:
+# -----------------
+# CMake initial-cache file for GCC 11 on Linux x86_64.
+# This file sets essential CMake variables and compiler/linker flags
+# to streamline the build process for Linux targets.
+#=======================================================================]
+
+#[=======================================================================[
+.rst:
+gcc11_linux_x86_64
+-------------------
+CMake initial cache file for GCC 11 on Linux x86_64.
+
+All variables can be set as initial cache variables and passed as a file to CMake:
+
+.. code-block:: cmake
+
+    # Create an initial cache file (gcc11_linux_x86_64.cmake) and define in there:
+    set(CMAKE_PREFIX_PATH "/usr/local/gcc-11" CACHE STRING "")
+    set(CMAKE_TOOLCHAIN_FILE "/path/to/toolchain/gcc11_linux_x86_64.cmake" CACHE PATH "")
+
+.. code-block:: shell-session
+
+    $ cmake -C CMake/CMakeConfig/gcc11_linux_x86_64.cmake -S <project-root> -B <build-dir>
+
+#]=======================================================================]
+
+#[=======================================================================[
+  CMake Specific Project Settings
+#]=======================================================================]
+
+#=======================================================================
+# Library Building Preferences
+#=======================================================================
+#
+# Control whether to build shared or static libraries.
+# Set to ON to build shared libraries, OFF to build static libraries.
+#
+# Recommended: OFF for static libraries to simplify deployment.
+#=======================================================================
+message(STATUS "Using gcc11_linux_x86_64.cmake for initial cache setup.")
+
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")
+
+#=======================================================================
+# Compiler Configuration for C
+#=======================================================================
+#
+# These flags are used by the C compiler during respective build types.
+# Adjust them according to your project's requirements and target environment.
+#
+# Flags:
+#   -Wall, -Wextra: Enable most compiler warnings.
+#   -Wconversion: Warn for implicit type conversions that may alter a value.
+#   -pedantic: Enforce strict ISO compliance.
+#   -Wshadow: Warn when a variable shadows another variable.
+#=======================================================================
+set(CMAKE_C_FLAGS_INIT "-Wall -Wextra -Wconversion -pedantic -Wshadow" CACHE STRING "Initial C Compiler Flags")
+
+#-----------------------------------------------------------------------
+# Build-Type Specific C Flags
+#-----------------------------------------------------------------------
+# Flags for Debug build: No optimization, include debug symbols.
+set(CMAKE_C_FLAGS_DEBUG_INIT "-O0 -g" CACHE STRING "C Compiler Flags for Debug")
+
+# Flags for MinSizeRel build: Optimize for size, define NDEBUG.
+set(CMAKE_C_FLAGS_MINSIZEREL_INIT "-Os -DNDEBUG" CACHE STRING "C Compiler Flags for MinSizeRel")
+
+# Flags for Release build: Optimize for speed, define NDEBUG.
+set(CMAKE_C_FLAGS_RELEASE_INIT "-O3 -DNDEBUG" CACHE STRING "C Compiler Flags for Release")
+
+# Flags for RelWithDebInfo build: Optimize with debug symbols.
+set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "-O2 -g -DNDEBUG" CACHE STRING "C Compiler Flags for RelWithDebInfo")
+
+# Additional sanitizer flags for special build types.
+set(CMAKE_C_FLAGS_ALSAN_INIT "-fsanitize=address -fno-omit-frame-pointer" CACHE STRING "C Compiler Flags for Address Sanitizer")
+set(CMAKE_C_FLAGS_TSAN_INIT "-fsanitize=thread" CACHE STRING "C Compiler Flags for Thread Sanitizer")
+set(CMAKE_C_FLAGS_UBSAN_INIT "-fsanitize=undefined" CACHE STRING "C Compiler Flags for Undefined Behavior Sanitizer")
+
+#=======================================================================
+# Compiler Configuration for C++
+#=======================================================================
+#
+# These flags are used by the C++ compiler during respective build types.
+# Adjust them according to your project's requirements and target environment.
+#
+# Flags:
+#   -Wall, -Wextra: Enable most compiler warnings.
+#   -Wnon-virtual-dtor: Warn if a class with virtual functions has a non-virtual destructor.
+#   -Wconversion: Warn for implicit type conversions that may alter a value.
+#   -Wold-style-cast: Warn about C-style casts.
+#   -pedantic: Enforce strict ISO compliance.
+#   -Wshadow: Warn when a variable shadows another variable.
+#=======================================================================
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wnon-virtual-dtor -Wconversion -Wold-style-cast -pedantic -Wshadow" CACHE STRING "Initial C++ Compiler Flags")
+
+#-----------------------------------------------------------------------
+# Build-Type Specific C++ Flags
+#-----------------------------------------------------------------------
+# Flags for Debug build: No optimization, include debug symbols.
+set(CMAKE_CXX_FLAGS_DEBUG_INIT "-O0 -g" CACHE STRING "C++ Compiler Flags for Debug")
+
+# Flags for MinSizeRel build: Optimize for size, define NDEBUG.
+set(CMAKE_CXX_FLAGS_MINSIZEREL_INIT "-Os -DNDEBUG" CACHE STRING "C++ Compiler Flags for MinSizeRel")
+
+# Flags for Release build: Optimize for speed, define NDEBUG.
+set(CMAKE_CXX_FLAGS_RELEASE_INIT "-O3 -DNDEBUG" CACHE STRING "C++ Compiler Flags for Release")
+
+# Flags for RelWithDebInfo build: Optimize with debug symbols.
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "-O2 -g -DNDEBUG" CACHE STRING "C++ Compiler Flags for RelWithDebInfo")
+
+# Additional sanitizer flags for special build types.
+set(CMAKE_CXX_FLAGS_ALSAN_INIT "-fsanitize=address -fno-omit-frame-pointer" CACHE STRING "C++ Compiler Flags for Address Sanitizer")
+set(CMAKE_CXX_FLAGS_TSAN_INIT "-fsanitize=thread" CACHE STRING "C++ Compiler Flags for Thread Sanitizer")
+set(CMAKE_CXX_FLAGS_UBSAN_INIT "-fsanitize=undefined" CACHE STRING "C++ Compiler Flags for Undefined Behavior Sanitizer")
+
+#=======================================================================
+# Linker Flags Configuration
+#=======================================================================
+#
+# These flags are used by the linker during respective build types.
+# Adjust them based on your project's requirements and target environment.
+#=======================================================================
+
+#=======================================================================
+# Executable Linker Flags
+#=======================================================================
+#
+# Initial flags for the executable linker applicable to all build types.
+#=======================================================================
+set(CMAKE_EXE_LINKER_FLAGS_INIT "" CACHE STRING "Initial Executable Linker Flags")
+
+#-----------------------------------------------------------------------
+# Build-Type Specific Executable Linker Flags
+#-----------------------------------------------------------------------
+# Flags for Debug build: Include debug symbols.
+set(CMAKE_EXE_LINKER_FLAGS_DEBUG_INIT "-g" CACHE STRING "Executable Linker Flags for Debug")
+
+# Flags for MinSizeRel build: Strip symbols to reduce size.
+set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL_INIT "-s" CACHE STRING "Executable Linker Flags for MinSizeRel")
+
+# Flags for Release build: No additional flags.
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE_INIT "" CACHE STRING "Executable Linker Flags for Release")
+
+# Flags for RelWithDebInfo build: Include debug symbols.
+set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO_INIT "-g" CACHE STRING "Executable Linker Flags for RelWithDebInfo")
+
+#=======================================================================
+# Additional CMake Settings
+#=======================================================================
+#
+# Add any additional CMake variables and configurations below as needed.
+# This section is reserved for any project-specific settings that do not
+# fit into the categories above.
+#
+# Example:
+# set(SOME_PROJECT_VARIABLE "value" CACHE STRING "Description of the variable")
+#
+#=======================================================================

--- a/CMake/CMakeConfig/qcc12_qnx800_aarch64.cmake
+++ b/CMake/CMakeConfig/qcc12_qnx800_aarch64.cmake
@@ -1,0 +1,293 @@
+#[=======================================================================[
+# Copyright (c) 2024 by Your Company.
+# All rights reserved.
+#
+# This software is copyright protected and proprietary to Your
+# Company. You are granted only those rights as set out in the
+# license conditions. All other rights remain with Your Company.
+#
+# File description:
+# -----------------
+# CMake initial-cache file for OpenAA - QNX 8.0 aarch64 using QCC-12.
+# This file sets essential CMake variables and compiler/linker flags
+# to streamline the build process.
+#=======================================================================]
+
+#[=======================================================================[
+.rst:
+QNX800_AARCH64_QCC12
+---------------------
+CMake initial cache file for QNX 8.0 aarch64 using QCC-12.
+
+All variables can be set as initial cache variables and passed as a file to CMake:
+
+.. code-block:: cmake
+
+    # Create an initial cache file (qcc12_qnx800_aarch64.cmake) and define in there:
+    set(CMAKE_PREFIX_PATH "/opt/qnx800/host/linux/x86_64/usr" CACHE STRING "")
+    set(CMAKE_TOOLCHAIN_FILE "/opt/toolchain/qcc12_qnx800_aarch64.cmake" CACHE PATH "")
+
+.. code-block:: shell-session
+
+    # QNX dev kit can only be used with bash!
+    $ bash -i
+    $ source /opt/qnx800/qnxsdp-env.sh
+    $ cmake -C CMake/CMakeConfig/qcc12_qnx800_aarch64.cmake -S <project-root> -B <build-dir>
+
+Platform, quality, and product-specific build caches can be defined externally without
+unnecessarily inflating or patching CMakeLists.txt files contained in the project.
+
+Fixed development processes for construction, testing, and packaging can be generalized
+independently of the project.
+
+.. note::
+
+    Set the environment variables before you initialize the cache in respect to the
+    actual paths on your machine! To use the QNX dev kit, one must use bash and
+    source the file /opt/qnx800/qnxsdp-env.sh!
+#]=======================================================================]
+
+#[=======================================================================[
+  CMake Specific Project Settings
+#]=======================================================================]
+
+#=======================================================================
+# Library Building Preferences
+#=======================================================================
+#
+# Control whether to build shared or static libraries.
+# Set to ON to build shared libraries, OFF to build static libraries.
+#
+# Recommended: OFF for static libraries to simplify deployment.
+#=======================================================================
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")
+
+#=======================================================================
+# Compiler Configuration for C
+#=======================================================================
+#
+# These flags are used by the C compiler during respective build types.
+# Adjust them according to your project's requirements and target environment.
+#
+# Flags:
+#   -Wall, -Wextra: Enable most compiler warnings.
+#   -Wconversion: Warn for implicit type conversions that may alter a value.
+#   -pedantic: Enforce strict ISO compliance.
+#   -Wshadow: Warn when a variable shadows another variable.
+#   -D_QNX_SOURCE: Define _QNX_SOURCE macro for QNX-specific features.
+#=======================================================================
+set(CMAKE_C_FLAGS_INIT "-Wall -Wextra -Wconversion -pedantic -Wshadow -D_QNX_SOURCE" CACHE STRING "Initial C Compiler Flags")
+
+#-----------------------------------------------------------------------
+# Build-Type Specific C Flags
+#-----------------------------------------------------------------------
+# Flags for Debug build: No optimization, include debug symbols.
+set(CMAKE_C_FLAGS_DEBUG_INIT "-O0 -g" CACHE STRING "C Compiler Flags for Debug")
+
+# Flags for MinSizeRel build: Optimize for size, define NDEBUG.
+set(CMAKE_C_FLAGS_MINSIZEREL_INIT "-Os -DNDEBUG" CACHE STRING "C Compiler Flags for MinSizeRel")
+
+# Flags for Release build: Optimize for speed, define NDEBUG.
+set(CMAKE_C_FLAGS_RELEASE_INIT "-O3 -DNDEBUG" CACHE STRING "C Compiler Flags for Release")
+
+# Flags for RelWithDebInfo build: Optimize with debug symbols.
+set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "-O2 -g -DNDEBUG" CACHE STRING "C Compiler Flags for RelWithDebInfo")
+
+# Additional sanitizer flags for special build types.
+set(CMAKE_C_FLAGS_ALSAN_INIT "-fsanitize=address -fno-omit-frame-pointer" CACHE STRING "C Compiler Flags for Address Sanitizer")
+set(CMAKE_C_FLAGS_TSAN_INIT "-fsanitize=thread" CACHE STRING "C Compiler Flags for Thread Sanitizer")
+set(CMAKE_C_FLAGS_UBSAN_INIT "-fsanitize=undefined" CACHE STRING "C Compiler Flags for Undefined Behavior Sanitizer")
+set(CMAKE_C_FLAGS_RELEASEWITHO2_INIT "-O2 -DNDEBUG" CACHE STRING "C Compiler Flags for ReleaseWithO2")
+
+#=======================================================================
+# Compiler Configuration for C++
+#=======================================================================
+#
+# These flags are used by the C++ compiler during respective build types.
+# Adjust them according to your project's requirements and target environment.
+#
+# Flags:
+#   -Wall, -Wextra: Enable most compiler warnings.
+#   -Wnon-virtual-dtor: Warn if a class with virtual functions has a non-virtual destructor.
+#   -Wconversion: Warn for implicit type conversions that may alter a value.
+#   -Wold-style-cast: Warn about C-style casts.
+#   -pedantic: Enforce strict ISO compliance.
+#   -Wshadow: Warn when a variable shadows another variable.
+#   -Wno-error=deprecated-declarations: Do not treat deprecated declarations as errors.
+#   -v: Verbose output during compilation.
+#   -D_QNX_SOURCE: Define _QNX_SOURCE macro for QNX-specific features.
+#=======================================================================
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wnon-virtual-dtor -Wconversion -Wold-style-cast -pedantic -Wshadow -Wno-error=deprecated-declarations -v -D_QNX_SOURCE" CACHE STRING "Initial C++ Compiler Flags")
+
+#-----------------------------------------------------------------------
+# Build-Type Specific C++ Flags
+#-----------------------------------------------------------------------
+# Flags for Debug build: No optimization, include debug symbols.
+set(CMAKE_CXX_FLAGS_DEBUG_INIT "-O0 -g" CACHE STRING "C++ Compiler Flags for Debug")
+
+# Flags for MinSizeRel build: Optimize for size, define NDEBUG.
+set(CMAKE_CXX_FLAGS_MINSIZEREL_INIT "-Os -DNDEBUG" CACHE STRING "C++ Compiler Flags for MinSizeRel")
+
+# Flags for Release build: Optimize for speed, define NDEBUG.
+set(CMAKE_CXX_FLAGS_RELEASE_INIT "-O3 -DNDEBUG" CACHE STRING "C++ Compiler Flags for Release")
+
+# Flags for RelWithDebInfo build: Optimize with debug symbols.
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "-O2 -g -DNDEBUG" CACHE STRING "C++ Compiler Flags for RelWithDebInfo")
+
+# Additional sanitizer flags for special build types.
+set(CMAKE_CXX_FLAGS_ALSAN_INIT "-fsanitize=address -fno-omit-frame-pointer" CACHE STRING "C++ Compiler Flags for Address Sanitizer")
+set(CMAKE_CXX_FLAGS_TSAN_INIT "-fsanitize=thread" CACHE STRING "C++ Compiler Flags for Thread Sanitizer")
+set(CMAKE_CXX_FLAGS_UBSAN_INIT "-fsanitize=undefined" CACHE STRING "C++ Compiler Flags for Undefined Behavior Sanitizer")
+set(CMAKE_CXX_FLAGS_RELEASEWITHO2_INIT "-O2 -DNDEBUG" CACHE STRING "C++ Compiler Flags for ReleaseWithO2")
+
+#=======================================================================
+# Linker Flags Configuration
+#=======================================================================
+#
+# These flags are used by the linker during respective build types.
+# Adjust them based on your project's requirements and target environment.
+#=======================================================================
+
+#=======================================================================
+# Executable Linker Flags
+#=======================================================================
+#
+# Initial flags for the executable linker applicable to all build types.
+#=======================================================================
+set(CMAKE_EXE_LINKER_FLAGS_INIT "" CACHE STRING "Initial Executable Linker Flags")
+
+#-----------------------------------------------------------------------
+# Build-Type Specific Executable Linker Flags
+#-----------------------------------------------------------------------
+# Flags for Debug build: Include debug symbols.
+set(CMAKE_EXE_LINKER_FLAGS_DEBUG_INIT "-g" CACHE STRING "Executable Linker Flags for Debug")
+
+# Flags for MinSizeRel build: Strip symbols to reduce size.
+set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL_INIT "-s" CACHE STRING "Executable Linker Flags for MinSizeRel")
+
+# Flags for Release build: No additional flags.
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE_INIT "" CACHE STRING "Executable Linker Flags for Release")
+
+# Flags for RelWithDebInfo build: Include debug symbols.
+set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO_INIT "-g" CACHE STRING "Executable Linker Flags for RelWithDebInfo")
+
+# Flags for ReleaseWithO2 build: No additional flags.
+set(CMAKE_EXE_LINKER_FLAGS_RELEASEWITHO2_INIT "" CACHE STRING "Executable Linker Flags for ReleaseWithO2")
+
+#=======================================================================
+# Module Linker Flags
+#=======================================================================
+#
+# Initial flags for the module linker applicable to all build types.
+#=======================================================================
+set(CMAKE_MODULE_LINKER_FLAGS_INIT "" CACHE STRING "Initial Module Linker Flags")
+
+#-----------------------------------------------------------------------
+# Build-Type Specific Module Linker Flags
+#-----------------------------------------------------------------------
+# Flags for Debug build: No additional flags.
+set(CMAKE_MODULE_LINKER_FLAGS_DEBUG_INIT "" CACHE STRING "Module Linker Flags for Debug")
+
+# Flags for MinSizeRel build: No additional flags.
+set(CMAKE_MODULE_LINKER_FLAGS_MINSIZEREL_INIT "" CACHE STRING "Module Linker Flags for MinSizeRel")
+
+# Flags for Release build: No additional flags.
+set(CMAKE_MODULE_LINKER_FLAGS_RELEASE_INIT "" CACHE STRING "Module Linker Flags for Release")
+
+# Flags for RelWithDebInfo build: No additional flags.
+set(CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO_INIT "" CACHE STRING "Module Linker Flags for RelWithDebInfo")
+
+# Flags for ReleaseWithO2 build: No additional flags.
+set(CMAKE_MODULE_LINKER_FLAGS_RELEASEWITHO2_INIT "" CACHE STRING "Module Linker Flags for ReleaseWithO2")
+
+#=======================================================================
+# Shared Library Linker Flags
+#=======================================================================
+#
+# Initial flags for the shared library linker applicable to all build types.
+#=======================================================================
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "" CACHE STRING "Initial Shared Library Linker Flags")
+
+#-----------------------------------------------------------------------
+# Build-Type Specific Shared Library Linker Flags
+#-----------------------------------------------------------------------
+# Flags for Debug build: No additional flags.
+set(CMAKE_SHARED_LINKER_FLAGS_DEBUG_INIT "" CACHE STRING "Shared Library Linker Flags for Debug")
+
+# Flags for MinSizeRel build: No additional flags.
+set(CMAKE_SHARED_LINKER_FLAGS_MINSIZEREL_INIT "" CACHE STRING "Shared Library Linker Flags for MinSizeRel")
+
+# Flags for Release build: No additional flags.
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASE_INIT "" CACHE STRING "Shared Library Linker Flags for Release")
+
+# Flags for RelWithDebInfo build: No additional flags.
+set(CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO_INIT "" CACHE STRING "Shared Library Linker Flags for RelWithDebInfo")
+
+# Flags for ReleaseWithO2 build: No additional flags.
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASEWITHO2_INIT "" CACHE STRING "Shared Library Linker Flags for ReleaseWithO2")
+
+#=======================================================================
+# Static Library Linker Flags
+#=======================================================================
+#
+# Initial flags for the static library linker applicable to all build types.
+#=======================================================================
+set(CMAKE_STATIC_LINKER_FLAGS_INIT "" CACHE STRING "Initial Static Library Linker Flags")
+
+#-----------------------------------------------------------------------
+# Build-Type Specific Static Library Linker Flags
+#-----------------------------------------------------------------------
+# Flags for Debug build: No additional flags.
+set(CMAKE_STATIC_LINKER_FLAGS_DEBUG_INIT "" CACHE STRING "Static Library Linker Flags for Debug")
+
+# Flags for MinSizeRel build: No additional flags.
+set(CMAKE_STATIC_LINKER_FLAGS_MINSIZEREL_INIT "" CACHE STRING "Static Library Linker Flags for MinSizeRel")
+
+# Flags for Release build: No additional flags.
+set(CMAKE_STATIC_LINKER_FLAGS_RELEASE_INIT "" CACHE STRING "Static Library Linker Flags for Release")
+
+# Flags for RelWithDebInfo build: No additional flags.
+set(CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO_INIT "" CACHE STRING "Static Library Linker Flags for RelWithDebInfo")
+
+# Flags for ReleaseWithO2 build: No additional flags.
+set(CMAKE_STATIC_LINKER_FLAGS_RELEASEWITHO2_INIT "" CACHE STRING "Static Library Linker Flags for ReleaseWithO2")
+
+#=======================================================================
+# Installation Directory Variables
+#=======================================================================
+#
+# CMake provides standard installation directory variables when
+# include(GNUInstallDirs) is used in CMakeLists.txt. Customize them
+# here to suit your project's requirements.
+#
+# Reference:
+#   https://www.gnu.org/prep/standards/html_node/Directory-Variables.html
+#
+# Uncomment and modify the following lines if you need to override the defaults.
+#=======================================================================
+
+# Object code libraries (lib)
+# set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Installation directory for libraries" FORCE)
+
+# User executables (bin)
+# set(CMAKE_INSTALL_BINDIR "opt" CACHE STRING "Installation directory for executables" FORCE)
+
+# Read-only single-machine data (etc)
+# set(CMAKE_INSTALL_SYSCONFDIR "etc" CACHE STRING "Installation directory for configuration files" FORCE)
+
+# Modifiable single-machine data (var)
+# set(CMAKE_INSTALL_LOCALSTATEDIR "var" CACHE STRING "Installation directory for variable data" FORCE)
+
+#=======================================================================
+# Additional CMake Settings
+#=======================================================================
+#
+# Add any additional CMake variables and configurations below as needed.
+# This section is reserved for any project-specific settings that do not
+# fit into the categories above.
+#
+# Example:
+# set(SOME_PROJECT_VARIABLE "value" CACHE STRING "Description of the variable")
+#
+#=======================================================================
+

--- a/CMake/CMakeConfig/qcc12_qnx800_aarch64_debug.cmake
+++ b/CMake/CMakeConfig/qcc12_qnx800_aarch64_debug.cmake
@@ -1,6 +1,6 @@
-#[=======================================================================[
-# Copyright (c) 2024 by Your Company.
-# All rights reserved.
+#[=======================================================================
+# OpenAA: Open Source Adaptive AUTOSAR Project
+# Author: Sherif Mohamed
 #
 # This software is copyright protected and proprietary to Your
 # Company. You are granted only those rights as set out in the

--- a/CMake/CMakeConfig/qcc12_qnx800_aarch64_debug.cmake
+++ b/CMake/CMakeConfig/qcc12_qnx800_aarch64_debug.cmake
@@ -1,0 +1,87 @@
+#[=======================================================================[
+# Copyright (c) 2024 by Your Company.
+# All rights reserved.
+#
+# This software is copyright protected and proprietary to Your
+# Company. You are granted only those rights as set out in the
+# license conditions. All other rights remain with Your Company.
+#
+# File description:
+# -----------------
+# CMake initial-cache file for OpenAA - QNX 8.0 aarch64 using QCC-12.
+# Debug build configuration with enhanced warnings and ISO compliance.
+#=======================================================================]
+
+#[=======================================================================[
+.rst:
+QNX800_AARCH64_QCC12_DEBUG
+---------------------------
+CMake initial cache file for QNX 8.0 aarch64 debug builds using QCC-12.
+
+This file sets essential CMake variables and compiler/linker flags to support
+debugging, such as including debug symbols, disabling optimizations, and enabling
+maximum warnings for ISO compliance.
+
+.. code-block:: shell-session
+
+    # QNX dev kit can only be used with bash!
+    $ bash -i
+    $ source /opt/qnx800/qnxsdp-env.sh
+    $ cmake -C CMake/CMakeConfig/qcc12_qnx800_aarch64_debug.cmake -S <project-root> -B <build-dir>
+
+#]=======================================================================]
+
+message(STATUS "Using qcc12_qnx800_aarch64_debug.cmake for debug build configuration.")
+
+#=======================================================================
+# Library Building Preferences
+#=======================================================================
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")
+
+#=======================================================================
+# Compiler Configuration for C
+#=======================================================================
+set(CMAKE_C_FLAGS_INIT "-Wall -Wextra -Wconversion -pedantic -Wshadow -Wdouble-promotion -Wformat=2 \
+-Wnull-dereference -D_QNX_SOURCE -g" CACHE STRING "Initial C Compiler Flags for Debug Build")
+
+set(CMAKE_C_FLAGS_DEBUG_INIT "-O0 -g3" CACHE STRING "C Compiler Flags for Debug Build")
+
+#=======================================================================
+# Compiler Configuration for C++
+#=======================================================================
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wnon-virtual-dtor -Wconversion -Wold-style-cast -pedantic \
+-Wshadow -Wno-error=deprecated-declarations -Wdouble-promotion -Wformat=2 -D_QNX_SOURCE -g" CACHE STRING "Initial C++ Compiler Flags for Debug Build")
+
+set(CMAKE_CXX_FLAGS_DEBUG_INIT "-O0 -g3" CACHE STRING "C++ Compiler Flags for Debug Build")
+
+#=======================================================================
+# Linker Flags Configuration
+#=======================================================================
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-g" CACHE STRING "Initial Executable Linker Flags for Debug")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "-g" CACHE STRING "Initial Shared Library Linker Flags for Debug")
+
+#=======================================================================
+# Build-Type Configuration
+#=======================================================================
+set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build type (Debug, Release, etc.)")
+
+#=======================================================================
+# Additional Debugging Features
+#=======================================================================
+set(CMAKE_C_FLAGS_ALSAN_INIT "-fsanitize=address -fno-omit-frame-pointer" CACHE STRING "Address Sanitizer Flags for C")
+set(CMAKE_CXX_FLAGS_ALSAN_INIT "-fsanitize=address -fno-omit-frame-pointer" CACHE STRING "Address Sanitizer Flags for C++")
+
+set(CMAKE_C_FLAGS_TSAN_INIT "-fsanitize=thread" CACHE STRING "Thread Sanitizer Flags for C")
+set(CMAKE_CXX_FLAGS_TSAN_INIT "-fsanitize=thread" CACHE STRING "Thread Sanitizer Flags for C++")
+
+set(CMAKE_C_FLAGS_UBSAN_INIT "-fsanitize=undefined" CACHE STRING "Undefined Behavior Sanitizer Flags for C")
+set(CMAKE_CXX_FLAGS_UBSAN_INIT "-fsanitize=undefined" CACHE STRING "Undefined Behavior Sanitizer Flags for C++")
+
+#=======================================================================
+# Notes for Debugging
+#=======================================================================
+# 1. Debug builds include extensive debugging information with `-g3`.
+# 2. Address, thread, and undefined behavior sanitizers are enabled to catch runtime issues.
+# 3. Warnings are set to maximum to enforce ISO compliance and detect potential issues.
+# 4. Optimizations are disabled (`-O0`) to facilitate debugging.
+#=======================================================================

--- a/CMake/CMakeConfig/qcc12_qnx800_aarch64_release.cmake
+++ b/CMake/CMakeConfig/qcc12_qnx800_aarch64_release.cmake
@@ -1,6 +1,6 @@
-#[=======================================================================[
-# Copyright (c) 2024 by Your Company.
-# All rights reserved.
+#[=======================================================================
+# OpenAA: Open Source Adaptive AUTOSAR Project
+# Author: Sherif Mohamed
 #
 # This software is copyright protected and proprietary to Your
 # Company. You are granted only those rights as set out in the

--- a/CMake/CMakeConfig/qcc12_qnx800_aarch64_release.cmake
+++ b/CMake/CMakeConfig/qcc12_qnx800_aarch64_release.cmake
@@ -60,6 +60,8 @@ independently of the project.
 #
 # Recommended: OFF for static libraries to simplify deployment.
 #=======================================================================
+message(STATUS "Using qcc12_qnx800_aarch64_release.cmake for initial cache setup.")
+
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")
 
 #=======================================================================

--- a/CMake/CMakeConfig/qcc12_qnx800_x86_64_debug.cmake
+++ b/CMake/CMakeConfig/qcc12_qnx800_x86_64_debug.cmake
@@ -1,0 +1,87 @@
+#[=======================================================================[
+# Copyright (c) 2024 by Your Company.
+# All rights reserved.
+#
+# This software is copyright protected and proprietary to Your
+# Company. You are granted only those rights as set out in the
+# license conditions. All other rights remain with Your Company.
+#
+# File description:
+# -----------------
+# CMake initial-cache file for OpenAA - QNX 8.0 x86_64 using QCC-12.
+# Debug build configuration with enhanced warnings and ISO compliance.
+#=======================================================================]
+
+#[=======================================================================[
+.rst:
+QNX800_x86_64_QCC12_DEBUG
+---------------------------
+CMake initial cache file for QNX 8.0 x86_64 debug builds using QCC-12.
+
+This file sets essential CMake variables and compiler/linker flags to support
+debugging, such as including debug symbols, disabling optimizations, and enabling
+maximum warnings for ISO compliance.
+
+.. code-block:: shell-session
+
+    # QNX dev kit can only be used with bash!
+    $ bash -i
+    $ source /opt/qnx800/qnxsdp-env.sh
+    $ cmake -C CMake/CMakeConfig/qcc12_qnx800_x86_64_debug.cmake -S <project-root> -B <build-dir>
+
+#]=======================================================================]
+
+message(STATUS "Using qcc12_qnx800_x86_64_debug.cmake for debug build configuration.")
+
+#=======================================================================
+# Library Building Preferences
+#=======================================================================
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")
+
+#=======================================================================
+# Compiler Configuration for C
+#=======================================================================
+set(CMAKE_C_FLAGS_INIT "-Wall -Wextra -Wconversion -pedantic -Wshadow -Wdouble-promotion -Wformat=2 \
+-Wnull-dereference -D_QNX_SOURCE -g" CACHE STRING "Initial C Compiler Flags for Debug Build")
+
+set(CMAKE_C_FLAGS_DEBUG_INIT "-O0 -g3" CACHE STRING "C Compiler Flags for Debug Build")
+
+#=======================================================================
+# Compiler Configuration for C++
+#=======================================================================
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wnon-virtual-dtor -Wconversion -Wold-style-cast -pedantic \
+-Wshadow -Wno-error=deprecated-declarations -Wdouble-promotion -Wformat=2 -D_QNX_SOURCE -g" CACHE STRING "Initial C++ Compiler Flags for Debug Build")
+
+set(CMAKE_CXX_FLAGS_DEBUG_INIT "-O0 -g3" CACHE STRING "C++ Compiler Flags for Debug Build")
+
+#=======================================================================
+# Linker Flags Configuration
+#=======================================================================
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-g" CACHE STRING "Initial Executable Linker Flags for Debug")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "-g" CACHE STRING "Initial Shared Library Linker Flags for Debug")
+
+#=======================================================================
+# Build-Type Configuration
+#=======================================================================
+set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build type (Debug, Release, etc.)")
+
+#=======================================================================
+# Additional Debugging Features
+#=======================================================================
+set(CMAKE_C_FLAGS_ALSAN_INIT "-fsanitize=address -fno-omit-frame-pointer" CACHE STRING "Address Sanitizer Flags for C")
+set(CMAKE_CXX_FLAGS_ALSAN_INIT "-fsanitize=address -fno-omit-frame-pointer" CACHE STRING "Address Sanitizer Flags for C++")
+
+set(CMAKE_C_FLAGS_TSAN_INIT "-fsanitize=thread" CACHE STRING "Thread Sanitizer Flags for C")
+set(CMAKE_CXX_FLAGS_TSAN_INIT "-fsanitize=thread" CACHE STRING "Thread Sanitizer Flags for C++")
+
+set(CMAKE_C_FLAGS_UBSAN_INIT "-fsanitize=undefined" CACHE STRING "Undefined Behavior Sanitizer Flags for C")
+set(CMAKE_CXX_FLAGS_UBSAN_INIT "-fsanitize=undefined" CACHE STRING "Undefined Behavior Sanitizer Flags for C++")
+
+#=======================================================================
+# Notes for Debugging
+#=======================================================================
+# 1. Debug builds include extensive debugging information with `-g3`.
+# 2. Address, thread, and undefined behavior sanitizers are enabled to catch runtime issues.
+# 3. Warnings are set to maximum to enforce ISO compliance and detect potential issues.
+# 4. Optimizations are disabled (`-O0`) to facilitate debugging.
+#=======================================================================

--- a/CMake/CMakeConfig/qcc12_qnx800_x86_64_release.cmake
+++ b/CMake/CMakeConfig/qcc12_qnx800_x86_64_release.cmake
@@ -1,6 +1,6 @@
-#[=======================================================================[
-# Copyright (c) 2024 by Your Company.
-# All rights reserved.
+#[=======================================================================
+# OpenAA: Open Source Adaptive AUTOSAR Project
+# Author: Sherif Mohamed
 #
 # This software is copyright protected and proprietary to Your
 # Company. You are granted only those rights as set out in the

--- a/CMake/CMakeConfig/qcc12_qnx800_x86_64_release.cmake
+++ b/CMake/CMakeConfig/qcc12_qnx800_x86_64_release.cmake
@@ -8,31 +8,31 @@
 #
 # File description:
 # -----------------
-# CMake initial-cache file for OpenAA - QNX 8.0 aarch64 using QCC-12.
+# CMake initial-cache file for OpenAA - QNX 8.0 x86_64 using QCC-12.
 # This file sets essential CMake variables and compiler/linker flags
 # to streamline the build process.
 #=======================================================================]
 
 #[=======================================================================[
 .rst:
-QNX800_AARCH64_QCC12
+QNX800_x86_64_QCC12
 ---------------------
-CMake initial cache file for QNX 8.0 aarch64 using QCC-12.
+CMake initial cache file for QNX 8.0 x86_64 using QCC-12.
 
 All variables can be set as initial cache variables and passed as a file to CMake:
 
 .. code-block:: cmake
 
-    # Create an initial cache file (qcc12_qnx800_aarch64.cmake) and define in there:
+    # Create an initial cache file (qcc12_qnx800_x86_64.cmake) and define in there:
     set(CMAKE_PREFIX_PATH "/opt/qnx800/host/linux/x86_64/usr" CACHE STRING "")
-    set(CMAKE_TOOLCHAIN_FILE "/opt/toolchain/qcc12_qnx800_aarch64.cmake" CACHE PATH "")
+    set(CMAKE_TOOLCHAIN_FILE "/opt/toolchain/qcc12_qnx800_x86_64.cmake" CACHE PATH "")
 
 .. code-block:: shell-session
 
     # QNX dev kit can only be used with bash!
     $ bash -i
     $ source /opt/qnx800/qnxsdp-env.sh
-    $ cmake -C CMake/CMakeConfig/qcc12_qnx800_aarch64.cmake -S <project-root> -B <build-dir>
+    $ cmake -C CMake/CMakeConfig/qcc12_qnx800_x86_64.cmake -S <project-root> -B <build-dir>
 
 Platform, quality, and product-specific build caches can be defined externally without
 unnecessarily inflating or patching CMakeLists.txt files contained in the project.
@@ -60,7 +60,7 @@ independently of the project.
 #
 # Recommended: OFF for static libraries to simplify deployment.
 #=======================================================================
-message(STATUS "Using qcc12_qnx800_aarch64_release.cmake for initial cache setup.")
+message(STATUS "Using qcc12_qnx800_x86_64_release.cmake for initial cache setup.")
 
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")
 
@@ -266,4 +266,3 @@ set(CMAKE_STATIC_LINKER_FLAGS_RELEASEWITHO2_INIT "" CACHE STRING "Static Library
 # set(SOME_PROJECT_VARIABLE "value" CACHE STRING "Description of the variable")
 #
 #=======================================================================
-

--- a/CMake/Toolchain/gcc11_linux_aarch64_debug.cmake
+++ b/CMake/Toolchain/gcc11_linux_aarch64_debug.cmake
@@ -1,0 +1,83 @@
+#[=======================================================================
+# OpenAA: Open Source Adaptive AUTOSAR Project
+# Author: Sherif Mohamed
+#
+# CMake Toolchain File
+# --------------------
+# Purpose:
+#   This file configures the CMake build system to use GCC/G++ version 11 compilers
+#   specifically targeting Linux aarch64 architectures. It also sets up various
+#   build tools and utilities required during the build process, ensuring
+#   compatibility and proper configuration.
+#
+# Key Features:
+#   - Configures the GCC 11 toolchain for C and C++.
+#   - Specifies tools for archiving, linking, and inspecting object files.
+#   - Configures `find` behavior for locating libraries, includes, and programs.
+#
+# Target Environment:
+#   - Operating System: Linux
+#   - Architecture: aarch64
+#   - Compiler: GCC/G++ version 11
+#==========================================================================================]
+
+#==========================================================================================
+# System Properties
+# ------------------
+# Defines the system version, name, and target processor architecture. This is critical
+# for ensuring that the build system generates code optimized for the specified platform.
+#==========================================================================================
+set(CMAKE_SYSTEM_VERSION   1)         # Placeholder system version, adjust as needed
+set(CMAKE_SYSTEM_NAME      Linux)     # Target system name
+set(CMAKE_SYSTEM_PROCESSOR aarch64)    # Target processor architecture
+
+#==========================================================================================
+# Find Root Path Modes
+# --------------------
+# Controls how CMake searches for programs, libraries, and includes during the build.
+# These settings are particularly useful for isolating the build environment in
+# cross-compilation scenarios or controlled build setups.
+#==========================================================================================
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)  # Do not search programs in the root path
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)   # Search libraries only in the root path
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)   # Search includes only in the root path
+
+#==========================================================================================
+# Compiler Settings
+# -----------------
+# Specifies the C and C++ compilers to be used. Explicitly setting the GCC version
+# ensures consistency, especially in environments with multiple compiler versions.
+#==========================================================================================
+set(CMAKE_C_COMPILER   aarch64-linux-gnu-gcc-11)       # C compiler (GCC version 11)
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++-11)       # C++ compiler (G++ version 11)
+
+#==========================================================================================
+# Archiver and Ranlib Settings
+# ----------------------------
+# Specifies the tools for creating and indexing static library archives. These tools
+# are crucial for managing `.a` files and ensuring fast linking during the build process.
+#==========================================================================================
+set(CMAKE_AR     aarch64-linux-gnu-ar     CACHE FILEPATH "Archiver for creating static libraries")
+set(CMAKE_RANLIB aarch64-linux-gnu-ranlib CACHE FILEPATH "Ranlib for indexing static libraries")
+
+#==========================================================================================
+# Utility Tools
+# -------------
+# Specifies additional tools used for inspecting, copying, and dumping object files.
+# These tools are helpful for debugging and analyzing compiled code.
+#==========================================================================================
+set(CMAKE_NM      aarch64-linux-gnu-nm      CACHE FILEPATH "Tool for listing symbols in object files")
+set(CMAKE_OBJCOPY aarch64-linux-gnu-objcopy CACHE FILEPATH "Tool for copying and translating object files")
+set(CMAKE_OBJDUMP aarch64-linux-gnu-objdump CACHE FILEPATH "Tool for displaying object file details")
+
+#==========================================================================================
+# GCC-Specific Tools for LTO (Link-Time Optimization)
+# ---------------------------------------------------
+# Specifies GCC-specific versions of archiver and ranlib. These tools are used to support
+# advanced optimization techniques like Link-Time Optimization (LTO), ensuring compatibility
+# with GCC's intermediate representations.
+#==========================================================================================
+set(CMAKE_C_COMPILER_AR       aarch64-linux-gnu-gcc-ar-11     CACHE FILEPATH "GCC-specific archiver for C")
+set(CMAKE_C_COMPILER_RANLIB   aarch64-linux-gnu-gcc-ranlib-11 CACHE FILEPATH "GCC-specific ranlib for C")
+set(CMAKE_CXX_COMPILER_AR     aarch64-linux-gnu-gcc-ar-11     CACHE FILEPATH "GCC-specific archiver for C++")
+set(CMAKE_CXX_COMPILER_RANLIB aarch64-linux-gnu-gcc-ranlib-11 CACHE FILEPATH "GCC-specific ranlib for C++")

--- a/CMake/Toolchain/gcc11_linux_aarch64_release.cmake
+++ b/CMake/Toolchain/gcc11_linux_aarch64_release.cmake
@@ -1,0 +1,83 @@
+#[=======================================================================
+# OpenAA: Open Source Adaptive AUTOSAR Project
+# Author: Sherif Mohamed
+#
+# CMake Toolchain File
+# --------------------
+# Purpose:
+#   This file configures the CMake build system to use GCC/G++ version 11 compilers
+#   specifically targeting Linux aarch64 architectures. It also sets up various
+#   build tools and utilities required during the build process, ensuring
+#   compatibility and proper configuration.
+#
+# Key Features:
+#   - Configures the GCC 11 toolchain for C and C++.
+#   - Specifies tools for archiving, linking, and inspecting object files.
+#   - Configures `find` behavior for locating libraries, includes, and programs.
+#
+# Target Environment:
+#   - Operating System: Linux
+#   - Architecture: aarch64
+#   - Compiler: GCC/G++ version 11
+#==========================================================================================]
+
+#==========================================================================================
+# System Properties
+# ------------------
+# Defines the system version, name, and target processor architecture. This is critical
+# for ensuring that the build system generates code optimized for the specified platform.
+#==========================================================================================
+set(CMAKE_SYSTEM_VERSION   1)         # Placeholder system version, adjust as needed
+set(CMAKE_SYSTEM_NAME      Linux)     # Target system name
+set(CMAKE_SYSTEM_PROCESSOR aarch64)    # Target processor architecture
+
+#==========================================================================================
+# Find Root Path Modes
+# --------------------
+# Controls how CMake searches for programs, libraries, and includes during the build.
+# These settings are particularly useful for isolating the build environment in
+# cross-compilation scenarios or controlled build setups.
+#==========================================================================================
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)  # Do not search programs in the root path
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)   # Search libraries only in the root path
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)   # Search includes only in the root path
+
+#==========================================================================================
+# Compiler Settings
+# -----------------
+# Specifies the C and C++ compilers to be used. Explicitly setting the GCC version
+# ensures consistency, especially in environments with multiple compiler versions.
+#==========================================================================================
+set(CMAKE_C_COMPILER   aarch64-linux-gnu-gcc-11)       # C compiler (GCC version 11)
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++-11)       # C++ compiler (G++ version 11)
+
+#==========================================================================================
+# Archiver and Ranlib Settings
+# ----------------------------
+# Specifies the tools for creating and indexing static library archives. These tools
+# are crucial for managing `.a` files and ensuring fast linking during the build process.
+#==========================================================================================
+set(CMAKE_AR     aarch64-linux-gnu-ar     CACHE FILEPATH "Archiver for creating static libraries")
+set(CMAKE_RANLIB aarch64-linux-gnu-ranlib CACHE FILEPATH "Ranlib for indexing static libraries")
+
+#==========================================================================================
+# Utility Tools
+# -------------
+# Specifies additional tools used for inspecting, copying, and dumping object files.
+# These tools are helpful for debugging and analyzing compiled code.
+#==========================================================================================
+set(CMAKE_NM      aarch64-linux-gnu-nm      CACHE FILEPATH "Tool for listing symbols in object files")
+set(CMAKE_OBJCOPY aarch64-linux-gnu-objcopy CACHE FILEPATH "Tool for copying and translating object files")
+set(CMAKE_OBJDUMP aarch64-linux-gnu-objdump CACHE FILEPATH "Tool for displaying object file details")
+
+#==========================================================================================
+# GCC-Specific Tools for LTO (Link-Time Optimization)
+# ---------------------------------------------------
+# Specifies GCC-specific versions of archiver and ranlib. These tools are used to support
+# advanced optimization techniques like Link-Time Optimization (LTO), ensuring compatibility
+# with GCC's intermediate representations.
+#==========================================================================================
+set(CMAKE_C_COMPILER_AR       aarch64-linux-gnu-gcc-ar-11     CACHE FILEPATH "GCC-specific archiver for C")
+set(CMAKE_C_COMPILER_RANLIB   aarch64-linux-gnu-gcc-ranlib-11 CACHE FILEPATH "GCC-specific ranlib for C")
+set(CMAKE_CXX_COMPILER_AR     aarch64-linux-gnu-gcc-ar-11     CACHE FILEPATH "GCC-specific archiver for C++")
+set(CMAKE_CXX_COMPILER_RANLIB aarch64-linux-gnu-gcc-ranlib-11 CACHE FILEPATH "GCC-specific ranlib for C++")

--- a/CMake/Toolchain/gcc11_linux_x86_64_debug.cmake
+++ b/CMake/Toolchain/gcc11_linux_x86_64_debug.cmake
@@ -1,0 +1,83 @@
+#[=======================================================================
+# OpenAA: Open Source Adaptive AUTOSAR Project
+# Author: Sherif Mohamed
+#
+# CMake Toolchain File
+# --------------------
+# Purpose:
+#   This file configures the CMake build system to use GCC/G++ version 11 compilers
+#   specifically targeting Linux x86_64 architectures. It also sets up various
+#   build tools and utilities required during the build process, ensuring
+#   compatibility and proper configuration.
+#
+# Key Features:
+#   - Configures the GCC 11 toolchain for C and C++.
+#   - Specifies tools for archiving, linking, and inspecting object files.
+#   - Configures `find` behavior for locating libraries, includes, and programs.
+#
+# Target Environment:
+#   - Operating System: Linux
+#   - Architecture: x86_64
+#   - Compiler: GCC/G++ version 11
+#==========================================================================================]
+
+#==========================================================================================
+# System Properties
+# ------------------
+# Defines the system version, name, and target processor architecture. This is critical
+# for ensuring that the build system generates code optimized for the specified platform.
+#==========================================================================================
+set(CMAKE_SYSTEM_VERSION   1)         # Placeholder system version, adjust as needed
+set(CMAKE_SYSTEM_NAME      Linux)     # Target system name
+set(CMAKE_SYSTEM_PROCESSOR x86_64)    # Target processor architecture
+
+#==========================================================================================
+# Find Root Path Modes
+# --------------------
+# Controls how CMake searches for programs, libraries, and includes during the build.
+# These settings are particularly useful for isolating the build environment in
+# cross-compilation scenarios or controlled build setups.
+#==========================================================================================
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)  # Do not search programs in the root path
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)   # Search libraries only in the root path
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)   # Search includes only in the root path
+
+#==========================================================================================
+# Compiler Settings
+# -----------------
+# Specifies the C and C++ compilers to be used. Explicitly setting the GCC version
+# ensures consistency, especially in environments with multiple compiler versions.
+#==========================================================================================
+set(CMAKE_C_COMPILER   gcc-11)       # C compiler (GCC version 11)
+set(CMAKE_CXX_COMPILER g++-11)       # C++ compiler (G++ version 11)
+
+#==========================================================================================
+# Archiver and Ranlib Settings
+# ----------------------------
+# Specifies the tools for creating and indexing static library archives. These tools
+# are crucial for managing `.a` files and ensuring fast linking during the build process.
+#==========================================================================================
+set(CMAKE_AR     ar     CACHE FILEPATH "Archiver for creating static libraries")
+set(CMAKE_RANLIB ranlib CACHE FILEPATH "Ranlib for indexing static libraries")
+
+#==========================================================================================
+# Utility Tools
+# -------------
+# Specifies additional tools used for inspecting, copying, and dumping object files.
+# These tools are helpful for debugging and analyzing compiled code.
+#==========================================================================================
+set(CMAKE_NM      nm      CACHE FILEPATH "Tool for listing symbols in object files")
+set(CMAKE_OBJCOPY objcopy CACHE FILEPATH "Tool for copying and translating object files")
+set(CMAKE_OBJDUMP objdump CACHE FILEPATH "Tool for displaying object file details")
+
+#==========================================================================================
+# GCC-Specific Tools for LTO (Link-Time Optimization)
+# ---------------------------------------------------
+# Specifies GCC-specific versions of archiver and ranlib. These tools are used to support
+# advanced optimization techniques like Link-Time Optimization (LTO), ensuring compatibility
+# with GCC's intermediate representations.
+#==========================================================================================
+set(CMAKE_C_COMPILER_AR       gcc-ar-11     CACHE FILEPATH "GCC-specific archiver for C")
+set(CMAKE_C_COMPILER_RANLIB   gcc-ranlib-11 CACHE FILEPATH "GCC-specific ranlib for C")
+set(CMAKE_CXX_COMPILER_AR     gcc-ar-11     CACHE FILEPATH "GCC-specific archiver for C++")
+set(CMAKE_CXX_COMPILER_RANLIB gcc-ranlib-11 CACHE FILEPATH "GCC-specific ranlib for C++")

--- a/CMake/Toolchain/gcc11_linux_x86_64_release.cmake
+++ b/CMake/Toolchain/gcc11_linux_x86_64_release.cmake
@@ -1,0 +1,83 @@
+#[=======================================================================
+# OpenAA: Open Source Adaptive AUTOSAR Project
+# Author: Sherif Mohamed
+#
+# CMake Toolchain File
+# --------------------
+# Purpose:
+#   This file configures the CMake build system to use GCC/G++ version 11 compilers
+#   specifically targeting Linux x86_64 architectures. It also sets up various
+#   build tools and utilities required during the build process, ensuring
+#   compatibility and proper configuration.
+#
+# Key Features:
+#   - Configures the GCC 11 toolchain for C and C++.
+#   - Specifies tools for archiving, linking, and inspecting object files.
+#   - Configures `find` behavior for locating libraries, includes, and programs.
+#
+# Target Environment:
+#   - Operating System: Linux
+#   - Architecture: x86_64
+#   - Compiler: GCC/G++ version 11
+#==========================================================================================]
+
+#==========================================================================================
+# System Properties
+# ------------------
+# Defines the system version, name, and target processor architecture. This is critical
+# for ensuring that the build system generates code optimized for the specified platform.
+#==========================================================================================
+set(CMAKE_SYSTEM_VERSION   1)         # Placeholder system version, adjust as needed
+set(CMAKE_SYSTEM_NAME      Linux)     # Target system name
+set(CMAKE_SYSTEM_PROCESSOR x86_64)    # Target processor architecture
+
+#==========================================================================================
+# Find Root Path Modes
+# --------------------
+# Controls how CMake searches for programs, libraries, and includes during the build.
+# These settings are particularly useful for isolating the build environment in
+# cross-compilation scenarios or controlled build setups.
+#==========================================================================================
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)  # Do not search programs in the root path
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)   # Search libraries only in the root path
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)   # Search includes only in the root path
+
+#==========================================================================================
+# Compiler Settings
+# -----------------
+# Specifies the C and C++ compilers to be used. Explicitly setting the GCC version
+# ensures consistency, especially in environments with multiple compiler versions.
+#==========================================================================================
+set(CMAKE_C_COMPILER   gcc-11)       # C compiler (GCC version 11)
+set(CMAKE_CXX_COMPILER g++-11)       # C++ compiler (G++ version 11)
+
+#==========================================================================================
+# Archiver and Ranlib Settings
+# ----------------------------
+# Specifies the tools for creating and indexing static library archives. These tools
+# are crucial for managing `.a` files and ensuring fast linking during the build process.
+#==========================================================================================
+set(CMAKE_AR     ar     CACHE FILEPATH "Archiver for creating static libraries")
+set(CMAKE_RANLIB ranlib CACHE FILEPATH "Ranlib for indexing static libraries")
+
+#==========================================================================================
+# Utility Tools
+# -------------
+# Specifies additional tools used for inspecting, copying, and dumping object files.
+# These tools are helpful for debugging and analyzing compiled code.
+#==========================================================================================
+set(CMAKE_NM      nm      CACHE FILEPATH "Tool for listing symbols in object files")
+set(CMAKE_OBJCOPY objcopy CACHE FILEPATH "Tool for copying and translating object files")
+set(CMAKE_OBJDUMP objdump CACHE FILEPATH "Tool for displaying object file details")
+
+#==========================================================================================
+# GCC-Specific Tools for LTO (Link-Time Optimization)
+# ---------------------------------------------------
+# Specifies GCC-specific versions of archiver and ranlib. These tools are used to support
+# advanced optimization techniques like Link-Time Optimization (LTO), ensuring compatibility
+# with GCC's intermediate representations.
+#==========================================================================================
+set(CMAKE_C_COMPILER_AR       gcc-ar-11     CACHE FILEPATH "GCC-specific archiver for C")
+set(CMAKE_C_COMPILER_RANLIB   gcc-ranlib-11 CACHE FILEPATH "GCC-specific ranlib for C")
+set(CMAKE_CXX_COMPILER_AR     gcc-ar-11     CACHE FILEPATH "GCC-specific archiver for C++")
+set(CMAKE_CXX_COMPILER_RANLIB gcc-ranlib-11 CACHE FILEPATH "GCC-specific ranlib for C++")

--- a/CMake/Toolchain/qcc12_qnx800_aarch64_debug.cmake
+++ b/CMake/Toolchain/qcc12_qnx800_aarch64_debug.cmake
@@ -1,0 +1,40 @@
+# CMake/Toolchain/qcc8_qnx8_aarch64le.cmake
+
+#[======================================================================
+# CMake Toolchain File for QNX 8.0 aarch64
+#]======================================================================]
+
+# Ensure QNX environment variables are set
+if((NOT DEFINED ENV{QNX_HOST}) OR (NOT DEFINED ENV{QNX_TARGET}))
+    message(FATAL_ERROR "Environment variables QNX_HOST and QNX_TARGET missing!!
+$ source /path/to/qnxsdp-env.sh\n")
+endif()
+
+# Set system properties
+set(CMAKE_SYSTEM_VERSION   8.0.0)
+set(CMAKE_SYSTEM_NAME      QNX)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+# Specify paths for finding programs, libraries, and includes
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# Specify the compilers
+set(CMAKE_C_COMPILER   qcc)
+set(CMAKE_CXX_COMPILER q++)
+
+# Define compiler targets
+set(CMAKE_C_COMPILER_TARGET   "12.2.0,gcc_ntoaarch64le")
+set(CMAKE_CXX_COMPILER_TARGET "12.2.0,gcc_ntoaarch64le")
+
+# Disable response files for object files if CMake version >= 3.23
+if(CMAKE_VERSION GREATER_EQUAL 3.23)
+    set(CMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS FALSE)
+    set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS FALSE)
+endif()
+
+# Set the system root to QNX target
+set(CMAKE_SYSROOT $ENV{QNX_TARGET})
+
+# Additional QNX 8.0 specific settings can be added here

--- a/CMake/Toolchain/qcc12_qnx800_aarch64_release.cmake
+++ b/CMake/Toolchain/qcc12_qnx800_aarch64_release.cmake
@@ -1,4 +1,4 @@
-# CMake/Toolchain/qcc8_qnx8_aarch64le.cmake
+# CMake/Toolchain/qcc12_qnx8_aarch64le.cmake
 
 #[======================================================================
 # CMake Toolchain File for QNX 8.0 aarch64
@@ -26,7 +26,7 @@ set(CMAKE_CXX_COMPILER q++)
 
 # Define compiler targets
 set(CMAKE_C_COMPILER_TARGET   "12.2.0,gcc_ntoaarch64le")
-set(CMAKE_CXX_COMPILER_TARGET "12.2.0,gcc_ntoaarch64le")
+set(CMAKE_CXX_COMPILER_TARGET "12.2.0,gcc_ntoaarch64le_cxx")
 
 # Disable response files for object files if CMake version >= 3.23
 if(CMAKE_VERSION GREATER_EQUAL 3.23)

--- a/CMake/Toolchain/qcc12_qnx800_aarch64_release.cmake
+++ b/CMake/Toolchain/qcc12_qnx800_aarch64_release.cmake
@@ -1,0 +1,40 @@
+# CMake/Toolchain/qcc8_qnx8_aarch64le.cmake
+
+#[======================================================================
+# CMake Toolchain File for QNX 8.0 aarch64
+#]======================================================================]
+
+# Ensure QNX environment variables are set
+if((NOT DEFINED ENV{QNX_HOST}) OR (NOT DEFINED ENV{QNX_TARGET}))
+    message(FATAL_ERROR "Environment variables QNX_HOST and QNX_TARGET missing!!
+$ source /path/to/qnxsdp-env.sh\n")
+endif()
+
+# Set system properties
+set(CMAKE_SYSTEM_VERSION   8.0.0)
+set(CMAKE_SYSTEM_NAME      QNX)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+# Specify paths for finding programs, libraries, and includes
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# Specify the compilers
+set(CMAKE_C_COMPILER   qcc)
+set(CMAKE_CXX_COMPILER q++)
+
+# Define compiler targets
+set(CMAKE_C_COMPILER_TARGET   "12.2.0,gcc_ntoaarch64le")
+set(CMAKE_CXX_COMPILER_TARGET "12.2.0,gcc_ntoaarch64le")
+
+# Disable response files for object files if CMake version >= 3.23
+if(CMAKE_VERSION GREATER_EQUAL 3.23)
+    set(CMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS FALSE)
+    set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS FALSE)
+endif()
+
+# Set the system root to QNX target
+set(CMAKE_SYSROOT $ENV{QNX_TARGET})
+
+# Additional QNX 8.0 specific settings can be added here

--- a/CMake/Toolchain/qcc12_qnx800_x86_64_debug.cmake
+++ b/CMake/Toolchain/qcc12_qnx800_x86_64_debug.cmake
@@ -1,19 +1,19 @@
-# CMake/Toolchain/qcc12_qnx8_aarch64le.cmake
+# CMake/Toolchain/qcc12_qnx8_x86_64.cmake
 
 #[======================================================================
-# CMake Toolchain File for QNX 8.0 aarch64
+# CMake Toolchain File for QNX 8.0 x86_64
 #]======================================================================]
 
 # Ensure QNX environment variables are set
 if((NOT DEFINED ENV{QNX_HOST}) OR (NOT DEFINED ENV{QNX_TARGET}))
-    message(FATAL_ERROR "Environment variables QNX_HOST and QNX_TARGET missing!!
-$ source /path/to/qnxsdp-env.sh\n")
+    message(FATAL_ERROR "Environment variables QNX_HOST and QNX_TARGET must be set.
+    $ source /path/to/qnxsdp-env.sh\n")
 endif()
 
 # Set system properties
 set(CMAKE_SYSTEM_VERSION   8.0.0)
 set(CMAKE_SYSTEM_NAME      QNX)
-set(CMAKE_SYSTEM_PROCESSOR aarch64)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
 
 # Specify paths for finding programs, libraries, and includes
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
@@ -25,8 +25,8 @@ set(CMAKE_C_COMPILER   qcc)
 set(CMAKE_CXX_COMPILER q++)
 
 # Define compiler targets
-set(CMAKE_C_COMPILER_TARGET   "12.2.0,gcc_ntoaarch64le")
-set(CMAKE_CXX_COMPILER_TARGET "12.2.0,gcc_ntoaarch64le_cxx")
+set(CMAKE_C_COMPILER_TARGET   "12.2.0,gcc_ntox86_64")
+set(CMAKE_CXX_COMPILER_TARGET "12.2.0,gcc_ntox86_64_cxx")
 
 # Disable response files for object files if CMake version >= 3.23
 if(CMAKE_VERSION GREATER_EQUAL 3.23)
@@ -36,5 +36,3 @@ endif()
 
 # Set the system root to QNX target
 set(CMAKE_SYSROOT $ENV{QNX_TARGET})
-
-# Additional QNX 8.0 specific settings can be added here

--- a/CMake/Toolchain/qcc12_qnx800_x86_64_release.cmake
+++ b/CMake/Toolchain/qcc12_qnx800_x86_64_release.cmake
@@ -1,19 +1,19 @@
-# CMake/Toolchain/qcc12_qnx8_aarch64le.cmake
+# CMake/Toolchain/qcc12_qnx8_x86_64.cmake
 
 #[======================================================================
-# CMake Toolchain File for QNX 8.0 aarch64
+# CMake Toolchain File for QNX 8.0 x86_64
 #]======================================================================]
 
 # Ensure QNX environment variables are set
 if((NOT DEFINED ENV{QNX_HOST}) OR (NOT DEFINED ENV{QNX_TARGET}))
-    message(FATAL_ERROR "Environment variables QNX_HOST and QNX_TARGET missing!!
-$ source /path/to/qnxsdp-env.sh\n")
+    message(FATAL_ERROR "Environment variables QNX_HOST and QNX_TARGET must be set.
+    $ source /path/to/qnxsdp-env.sh\n")
 endif()
 
 # Set system properties
 set(CMAKE_SYSTEM_VERSION   8.0.0)
 set(CMAKE_SYSTEM_NAME      QNX)
-set(CMAKE_SYSTEM_PROCESSOR aarch64)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
 
 # Specify paths for finding programs, libraries, and includes
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
@@ -25,8 +25,8 @@ set(CMAKE_C_COMPILER   qcc)
 set(CMAKE_CXX_COMPILER q++)
 
 # Define compiler targets
-set(CMAKE_C_COMPILER_TARGET   "12.2.0,gcc_ntoaarch64le")
-set(CMAKE_CXX_COMPILER_TARGET "12.2.0,gcc_ntoaarch64le_cxx")
+set(CMAKE_C_COMPILER_TARGET   "12.2.0,gcc_ntox86_64")
+set(CMAKE_CXX_COMPILER_TARGET "12.2.0,gcc_ntox86_64_cxx")
 
 # Disable response files for object files if CMake version >= 3.23
 if(CMAKE_VERSION GREATER_EQUAL 3.23)
@@ -36,5 +36,3 @@ endif()
 
 # Set the system root to QNX target
 set(CMAKE_SYSROOT $ENV{QNX_TARGET})
-
-# Additional QNX 8.0 specific settings can be added here

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,13 @@
-#[=======================================================================[
-OpenAA: Open Source Adaptive AUTOSAR Project
-Author: Sherif Mohamed
+# CMakeLists.txt
 
-File description:
------------------
-Root CMake configuration file for the AdaptiveAutosarCpp17 project.
+#[======================================================================
+# OpenAA: Open Source Adaptive AUTOSAR Project
+# Author: Sherif Mohamed
+#
+# File description:
+# -----------------
+# Root CMake configuration file for the AdaptiveAutosarCpp17 project.
+# Supports Linux and QNX aarch64 builds.
 #]=======================================================================]
 
 #****************************************************************************************************
@@ -33,13 +36,6 @@ set(CMAKE_CXX_EXTENSIONS OFF CACHE BOOL "Disable C++ Extensions")
 set(CMAKE_CXX_STANDARD_REQUIRED ON CACHE BOOL "Require C++ Standard")
 
 #****************************************************************************************************
-# Installation Configuration
-#****************************************************************************************************
-
-# Set the prefix for the installation commands to the root of the deployment package
-set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/install" CACHE PATH "Installation directory" FORCE)
-
-#****************************************************************************************************
 # Include Subdirectories
 #****************************************************************************************************
 
@@ -61,4 +57,5 @@ endif()
 #****************************************************************************************************
 
 # Explicitly set the C++ compiler to g++ or another compiler if needed
+# Uncomment and set if you want to enforce a specific compiler
 # set(CMAKE_CXX_COMPILER "g++")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -56,6 +56,14 @@
         "cacheVariables": {
           "CMAKE_PREFIX_PATH": "$env{QNX_HOST}/usr"
         }
+      },
+      {
+        "name": "gcc11_linux_x86_64_release",
+        "inherits": "base_unix_makefiles",
+        "description": "Releasue build using gcc11 for Linux x86_64",
+        "cacheVariables": {
+          "CMAKE_BUILD_TYPE": "Release"
+        }
       }
     ]
   }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -27,13 +27,35 @@
         "inherits": "base_unix_makefiles",
         "description": "Release build using QCC-12 for QNX 8.0 aarch64",
         "cacheVariables": {
-          "CMAKE_BUILD_TYPE": "Release"
+          "CMAKE_BUILD_TYPE": "Release",
+          "CMAKE_PREFIX_PATH": "$env{QNX_HOST}/usr"
         }
       },
       {
         "name": "qcc12_qnx800_aarch64_debug",
         "inherits": "base_unix_makefiles",
-        "description": "Release build using QCC-12 for QNX 8.0 aarch64"
+        "description": "Debug build using QCC-12 for QNX 8.0 aarch64",
+        "cacheVariables": {
+          "CMAKE_PREFIX_PATH": "$env{QNX_HOST}/usr"
+        }
+        
+      },
+      {
+        "name": "qcc12_qnx800_x86_64_release",
+        "inherits": "base_unix_makefiles",
+        "description": "Release build using QCC-12 for QNX 8.0 aarch64",
+        "cacheVariables": {
+          "CMAKE_BUILD_TYPE": "Release",
+          "CMAKE_PREFIX_PATH": "$env{QNX_HOST}/usr"
+        }
+      },
+      {
+        "name": "qcc12_qnx800_x86_64_debug",
+        "inherits": "base_unix_makefiles",
+        "description": "Debug build using QCC-12 for QNX 8.0 aarch64",
+        "cacheVariables": {
+          "CMAKE_PREFIX_PATH": "$env{QNX_HOST}/usr"
+        }
       }
     ]
   }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,35 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired": {
+      "major": 3,
+      "minor": 27,
+      "patch": 0
+    },
+    "configurePresets": [
+      {
+        "name": "base_unix_makefiles",
+        "hidden": true,
+        "generator": "Unix Makefiles",
+        "description": "Base Debug build using Unix Makefiles generator",
+        "binaryDir": "${sourceDir}/build/${presetName}",
+        "installDir": "${sourceDir}/install/${presetName}",
+        "toolchainFile": "${sourceDir}/CMake/Toolchain/${presetName}.cmake",
+        "cacheVariables": {
+          "CMAKE_BUILD_TYPE": "Debug",
+          "CMAKE_COLOR_MAKEFILE": true,
+          "CMAKE_VERBOSE_MAKEFILE": true,
+          "CMAKE_LINK_WHAT_YOU_USE": true,
+          "CMAKE_EXPORT_COMPILE_COMMANDS": true
+        }
+      },
+      {
+        "name": "qcc12_qnx800_aarch64_release",
+        "inherits": "base_unix_makefiles",
+        "description": "Release build using QCC-12 for QNX 8.0 aarch64",
+        "cacheVariables": {
+          "CMAKE_BUILD_TYPE": "Release"
+        }
+      }
+    ]
+  }
+  

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,6 +29,11 @@
         "cacheVariables": {
           "CMAKE_BUILD_TYPE": "Release"
         }
+      },
+      {
+        "name": "qcc12_qnx800_aarch64_debug",
+        "inherits": "base_unix_makefiles",
+        "description": "Release build using QCC-12 for QNX 8.0 aarch64"
       }
     ]
   }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -64,6 +64,11 @@
         "cacheVariables": {
           "CMAKE_BUILD_TYPE": "Release"
         }
+      },
+      {
+        "name": "gcc11_linux_x86_64_debug",
+        "inherits": "base_unix_makefiles",
+        "description": "Releasue build using gcc11 for Linux x86_64"
       }
     ]
   }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -68,7 +68,20 @@
       {
         "name": "gcc11_linux_x86_64_debug",
         "inherits": "base_unix_makefiles",
-        "description": "Releasue build using gcc11 for Linux x86_64"
+        "description": "Debug build using gcc11 for Linux x86_64"
+      },
+      {
+        "name": "gcc11_linux_aarch64_release",
+        "inherits": "base_unix_makefiles",
+        "description": "Releasue build using gcc11 for Linux aarch64",
+        "cacheVariables": {
+          "CMAKE_BUILD_TYPE": "Release"
+        }
+      },
+      {
+        "name": "gcc11_linux_aarch64_debug",
+        "inherits": "base_unix_makefiles",
+        "description": "Debug build using gcc11 for Linux aarch64"
       }
     ]
   }

--- a/build.sh
+++ b/build.sh
@@ -59,7 +59,7 @@ usage() {
     echo "  -c, --clean               Perform a clean build by removing build and install directories"
     echo "  -t, --build-type TYPE     Specify build type (e.g., Debug, Release). Default: Release"
     echo "  -j, --jobs N              Specify number of parallel jobs. Default: number of CPU cores"
-    echo "  -b, --build-target TARGET Specify build target (linux, qnx_aarch64). Default: linux"
+    echo "  -b, --build-target TARGET Specify build target (linux, qnx_aarch64, qnx_x86_64). Default: linux"
     echo "  -s, --sdp-path PATH       Specify the path to qnxsdp-env.sh for QNX builds"
     echo ""
     exit 1
@@ -73,9 +73,9 @@ cleanup() {
 
 # Function to source QNX environment if required
 setup_environment() {
-    if [ "$BUILD_TARGET" == "qnx_aarch64" ]; then
+    if [[ "$BUILD_TARGET" == qnx_aarch64 || "$BUILD_TARGET" == qnx_x86_64 ]]; then
         if [ -z "$SDP_PATH" ]; then
-            log ERROR "SDP path must be provided for QNX aarch64 builds."
+            log ERROR "SDP path must be provided for QNX builds."
             exit 1
         fi
         log INFO "Sourcing QNX SDP environment from: $SDP_PATH"
@@ -95,6 +95,15 @@ define_build_parameters() {
                 CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
             else
                 PRESET_NAME="qcc12_qnx800_aarch64_release"
+                CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
+            fi
+            ;;
+        qnx_x86_64)
+            if [ "$BUILD_TYPE" == "Debug" ]; then
+                PRESET_NAME="qcc12_qnx800_x86_64_debug"
+                CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
+            else
+                PRESET_NAME="qcc12_qnx800_x86_64_release"
                 CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
             fi
             ;;

--- a/build.sh
+++ b/build.sh
@@ -21,14 +21,13 @@
 set -e  # Exit on error
 
 # Default build options
-BUILD_TYPE="Release"
-NUM_JOBS=$(nproc)
-CLEAN_BUILD=false
-BUILD_TARGET="linux"
-SDP_PATH=""
-USE_PRESET=true
-PRESET_NAME=""
-CONFIG_FILE=""
+BUILD_TYPE="Release"                 # Default build type
+BUILD_TARGET="gcc11_linux_x86_64"    # Default build target
+NUM_JOBS=$(nproc)                    # Default to number of CPU cores
+CLEAN_BUILD=false                    # Default: no clean build
+SDP_PATH=""                          # Default: no QNX SDP path
+PRESET_NAME=""                       # Preset name based on build type and target
+CONFIG_FILE=""                       # Config file path
 
 #****************************************************************************************************
 # Logging Utility
@@ -57,9 +56,9 @@ usage() {
     echo "Options:"
     echo "  -h, --help                Show this help message and exit"
     echo "  -c, --clean               Perform a clean build by removing build and install directories"
-    echo "  -t, --build-type TYPE     Specify build type (e.g., Debug, Release). Default: Release"
+    echo "  -t, --build-type TYPE     Specify build type (Debug, Release). Default: Release"
     echo "  -j, --jobs N              Specify number of parallel jobs. Default: number of CPU cores"
-    echo "  -b, --build-target TARGET Specify build target (linux, qnx_aarch64, qnx_x86_64). Default: linux"
+    echo "  -b, --build-target TARGET Specify build target (gcc11_linux_x86_64, gcc11_linux_aarch64, qcc12_qnx_aarch64, qcc12_qnx_x86_64)"
     echo "  -s, --sdp-path PATH       Specify the path to qnxsdp-env.sh for QNX builds"
     echo ""
     exit 1
@@ -73,7 +72,7 @@ cleanup() {
 
 # Function to source QNX environment if required
 setup_environment() {
-    if [[ "$BUILD_TARGET" == qnx_aarch64 || "$BUILD_TARGET" == qnx_x86_64 ]]; then
+    if [[ "$BUILD_TARGET" == qcc12_qnx_aarch64 || "$BUILD_TARGET" == qcc12_qnx_x86_64 ]]; then
         if [ -z "$SDP_PATH" ]; then
             log ERROR "SDP path must be provided for QNX builds."
             exit 1
@@ -86,26 +85,37 @@ setup_environment() {
 # Function to define build parameters based on target and type
 define_build_parameters() {
     case $BUILD_TARGET in
-        linux)
-            PRESET_NAME="base_unix_makefiles"
+        gcc11_linux_x86_64)
+            if [ "$BUILD_TYPE" == "Debug" ]; then
+                PRESET_NAME="gcc11_linux_x86_64_debug"
+            else
+                PRESET_NAME="gcc11_linux_x86_64_release"
+            fi
+            CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
             ;;
-        qnx_aarch64)
+        gcc11_linux_aarch64)
+            if [ "$BUILD_TYPE" == "Debug" ]; then
+                PRESET_NAME="gcc11_linux_aarch64_debug"
+            else
+                PRESET_NAME="gcc11_linux_aarch64_release"
+            fi
+            CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
+            ;;
+        qcc12_qnx_aarch64)
             if [ "$BUILD_TYPE" == "Debug" ]; then
                 PRESET_NAME="qcc12_qnx800_aarch64_debug"
-                CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
             else
                 PRESET_NAME="qcc12_qnx800_aarch64_release"
-                CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
             fi
+            CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
             ;;
-        qnx_x86_64)
+        qcc12_qnx_x86_64)
             if [ "$BUILD_TYPE" == "Debug" ]; then
                 PRESET_NAME="qcc12_qnx800_x86_64_debug"
-                CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
             else
                 PRESET_NAME="qcc12_qnx800_x86_64_release"
-                CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
             fi
+            CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
             ;;
         *)
             log ERROR "Invalid build target: $BUILD_TARGET"

--- a/build.sh
+++ b/build.sh
@@ -79,19 +79,24 @@ setup_environment() {
             exit 1
         fi
         log INFO "Sourcing QNX SDP environment from: $SDP_PATH"
-        CONFIG_FILE="CMake/CMakeConfig/qcc12_qnx800_aarch64.cmake"
         source "$SDP_PATH"
     fi
 }
 
-# Function to define build parameters based on target
+# Function to define build parameters based on target and type
 define_build_parameters() {
     case $BUILD_TARGET in
         linux)
             PRESET_NAME="base_unix_makefiles"
             ;;
         qnx_aarch64)
-            PRESET_NAME="qcc12_qnx800_aarch64_release"
+            if [ "$BUILD_TYPE" == "Debug" ]; then
+                PRESET_NAME="qcc12_qnx800_aarch64_debug"
+                CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
+            else
+                PRESET_NAME="qcc12_qnx800_aarch64_release"
+                CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
+            fi
             ;;
         *)
             log ERROR "Invalid build target: $BUILD_TARGET"

--- a/build.sh
+++ b/build.sh
@@ -1,147 +1,201 @@
 #!/bin/bash
 
-#[======================================================================
+#[=======================================================================[
 # OpenAA: Open Source Adaptive AUTOSAR Project
 # Author: Sherif Mohamed
 #
 # File description:
 # -----------------
-# Build and installation script for the AdaptiveAutosarCpp17 project.
-# Supports configurable options and handles interruptions gracefully.
+# Functional programming style build script for AdaptiveAutosarCpp17.
+# Integrates:
+# - CMakePresets.json for build presets.
+# - Configuration file (-C option) for initial cache variables.
+# - Logging utility for better traceability.
+# - Modular, functional programming style for maintainability.
 #]=======================================================================]
 
 #****************************************************************************************************
 # Script Configuration
 #****************************************************************************************************
 
-# Exit immediately if a command exits with a non-zero status
-set -e
+set -e  # Exit on error
 
 # Default build options
 BUILD_TYPE="Release"
-INSTALL_DIR=""
 NUM_JOBS=$(nproc)
 CLEAN_BUILD=false
+BUILD_TARGET="linux"
+SDP_PATH=""
+USE_PRESET=true
+PRESET_NAME=""
+CONFIG_FILE=""
 
 #****************************************************************************************************
-# Function Definitions
+# Logging Utility
+#****************************************************************************************************
+
+log() {
+    local level=$1
+    local message=$2
+    local timestamp=$(date "+%Y-%m-%d %H:%M:%S")
+    case $level in
+        INFO) echo -e "\033[32m[INFO] [$timestamp] $message\033[0m" ;;
+        WARN) echo -e "\033[33m[WARN] [$timestamp] $message\033[0m" ;;
+        ERROR) echo -e "\033[31m[ERROR] [$timestamp] $message\033[0m" ;;
+        *) echo "[UNKNOWN] [$timestamp] $message" ;;
+    esac
+}
+
+#****************************************************************************************************
+# Functions
 #****************************************************************************************************
 
 # Function to display usage information
 usage() {
-    echo "Usage: $0 [OPTIONS]"
+    log INFO "Usage: $0 [OPTIONS]"
     echo ""
     echo "Options:"
-    echo "  -h, --help            Show this help message and exit"
-    echo "  -c, --clean           Perform a clean build by removing the build directory"
-    echo "  -t, --build-type TYPE Specify build type (e.g., Debug, Release). Default: Release"
-    echo "  -i, --install-dir DIR Specify installation directory. Default: install/"
-    echo "  -j, --jobs N          Specify number of parallel jobs. Default: number of CPU cores"
+    echo "  -h, --help                Show this help message and exit"
+    echo "  -c, --clean               Perform a clean build by removing build and install directories"
+    echo "  -t, --build-type TYPE     Specify build type (e.g., Debug, Release). Default: Release"
+    echo "  -j, --jobs N              Specify number of parallel jobs. Default: number of CPU cores"
+    echo "  -b, --build-target TARGET Specify build target (linux, qnx_aarch64). Default: linux"
+    echo "  -s, --sdp-path PATH       Specify the path to qnxsdp-env.sh for QNX builds"
     echo ""
     exit 1
 }
 
 # Function to handle cleanup on interruption
 cleanup() {
-    echo "Build interrupted. Cleaning up..."
+    log WARN "Build interrupted. Cleaning up..."
     exit 1
 }
 
-# Trap signals for graceful termination
-trap cleanup SIGINT SIGTERM
+# Function to source QNX environment if required
+setup_environment() {
+    if [ "$BUILD_TARGET" == "qnx_aarch64" ]; then
+        if [ -z "$SDP_PATH" ]; then
+            log ERROR "SDP path must be provided for QNX aarch64 builds."
+            exit 1
+        fi
+        log INFO "Sourcing QNX SDP environment from: $SDP_PATH"
+        CONFIG_FILE="CMake/CMakeConfig/qcc12_qnx800_aarch64.cmake"
+        source "$SDP_PATH"
+    fi
+}
 
-#****************************************************************************************************
-# Parse Command-Line Arguments
-#****************************************************************************************************
-
-while [[ "$#" -gt 0 ]]; do
-    case $1 in
-        -h|--help)
-            usage
+# Function to define build parameters based on target
+define_build_parameters() {
+    case $BUILD_TARGET in
+        linux)
+            PRESET_NAME="base_unix_makefiles"
             ;;
-        -c|--clean)
-            CLEAN_BUILD=true
-            ;;
-        -t|--build-type)
-            BUILD_TYPE="$2"
-            shift
-            ;;
-        -i|--install-dir)
-            INSTALL_DIR="$2"
-            shift
-            ;;
-        -j|--jobs)
-            NUM_JOBS="$2"
-            shift
+        qnx_aarch64)
+            PRESET_NAME="qcc12_qnx800_aarch64_release"
             ;;
         *)
-            echo "Unknown option: $1"
+            log ERROR "Invalid build target: $BUILD_TARGET"
             usage
             ;;
     esac
-    shift
-done
+}
 
-#****************************************************************************************************
-# Set Installation Directory
-#****************************************************************************************************
-
-if [ -z "$INSTALL_DIR" ]; then
-    INSTALL_DIR="${PWD}/install"
-fi
-
-#****************************************************************************************************
-# Define Build Directory
-#****************************************************************************************************
-
-BUILD_DIR="${PWD}/build"
-
-#****************************************************************************************************
-# Clean Build Directory if Requested
-#****************************************************************************************************
-
-if [ "$CLEAN_BUILD" = true ]; then
-    if [ -d "$BUILD_DIR" ]; then
-        echo "Removing existing build directory..."
-        rm -rvf "$BUILD_DIR"
-        if [ -d "$INSTALL_DIR" ]; then
-            echo "Removing existing install directory..."
-            rm -rvf "$INSTALL_DIR"
-        fi
+# Function to clean build and install directories if requested
+clean_directories() {
+    if [ "$CLEAN_BUILD" = true ]; then
+        local build_dir="${PWD}/build/${PRESET_NAME}"
+        local install_dir="${PWD}/install/${PRESET_NAME}"
+        log INFO "Cleaning build directory: $build_dir"
+        rm -rf "$build_dir"
+        log INFO "Cleaning install directory: $install_dir"
+        rm -rf "$install_dir"
     fi
-fi
+}
+
+# Function to configure the project using CMake
+configure_project() {
+    if [ -f "$CONFIG_FILE" ]; then
+        log INFO "Using configuration file: $CONFIG_FILE"
+        cmake -C "$CONFIG_FILE" --preset "$PRESET_NAME"
+    else
+        log WARN "Configuration file not found: $CONFIG_FILE. Proceeding without it."
+        cmake --preset "$PRESET_NAME"
+    fi
+}
+
+# Function to build the project
+build_project() {
+    local build_dir="${PWD}/build/${PRESET_NAME}"
+    log INFO "Building the project in: $build_dir"
+    cmake --build "$build_dir" -- -j"$NUM_JOBS"
+}
+
+# Function to install the project
+install_project() {
+    local build_dir="${PWD}/build/${PRESET_NAME}"
+    local install_dir="${PWD}/install/${PRESET_NAME}"
+    log INFO "Installing the project to: $install_dir"
+    cmake --install "$build_dir" --prefix "$install_dir"
+}
 
 #****************************************************************************************************
-# Create Build Directory
+# Main Function
 #****************************************************************************************************
 
-mkdir -p "${BUILD_DIR}"
-cd "${BUILD_DIR}"
+main() {
+    # Trap signals for cleanup on interruption
+    trap cleanup SIGINT SIGTERM
+
+    # Parse command-line arguments
+    while [[ "$#" -gt 0 ]]; do
+        case $1 in
+            -h|--help)
+                usage
+                ;;
+            -c|--clean)
+                CLEAN_BUILD=true
+                ;;
+            -t|--build-type)
+                BUILD_TYPE="$2"
+                shift
+                ;;
+            -j|--jobs)
+                NUM_JOBS="$2"
+                shift
+                ;;
+            -b|--build-target)
+                BUILD_TARGET="$2"
+                shift
+                ;;
+            -s|--sdp-path)
+                SDP_PATH="$2"
+                shift
+                ;;
+            *)
+                log ERROR "Unknown option: $1"
+                usage
+                ;;
+        esac
+        shift
+    done
+
+    # Setup environment and define parameters
+    setup_environment
+    define_build_parameters
+
+    # Clean directories if needed
+    clean_directories
+
+    # Configure, build, and install the project
+    configure_project
+    build_project
+    install_project
+
+    log INFO "Build completed successfully."
+}
 
 #****************************************************************************************************
-# Configure the Project
+# Execute Main Function
 #****************************************************************************************************
 
-cmake .. \
-    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
-    -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
-
-#****************************************************************************************************
-# Build the Project
-#****************************************************************************************************
-
-cmake --build . -- -j"${NUM_JOBS}"
-
-#****************************************************************************************************
-# Install the Project
-#****************************************************************************************************
-
-cmake --install .
-
-#****************************************************************************************************
-# Completion Message
-#****************************************************************************************************
-
-echo "Build and installation completed successfully."
-echo "Build type: ${BUILD_TYPE}"
-echo "Installed files are located in ${INSTALL_DIR}"
+main "$@"


### PR DESCRIPTION
This pull request updates the build environment and CMake configurations to improve support for GCC 11 and QNX QCC 12 toolchains targeting both x86_64 and aarch64 architectures. Key changes include:

Added Configurations:
CMake Configurations:

Added initial cache files for GCC 11 and QNX QCC 12 toolchains:
gcc11_linux_aarch64_debug.cmake
gcc11_linux_aarch64_release.cmake
gcc11_linux_x86_64_debug.cmake
gcc11_linux_x86_64_release.cmake
qcc12_qnx800_aarch64_debug.cmake
qcc12_qnx800_aarch64_release.cmake
qcc12_qnx800_x86_64_debug.cmake
qcc12_qnx800_x86_64_release.cmake
Toolchain Files:

Added toolchain files for GCC 11 and QNX QCC 12 toolchains:
gcc11_linux_aarch64_debug.cmake
gcc11_linux_aarch64_release.cmake
gcc11_linux_x86_64_debug.cmake
gcc11_linux_x86_64_release.cmake
qcc12_qnx800_aarch64_debug.cmake
qcc12_qnx800_aarch64_release.cmake
qcc12_qnx800_x86_64_debug.cmake
qcc12_qnx800_x86_64_release.cmake
Build Script Enhancements:
Updated build.sh to:
Support GCC 11 and QNX QCC 12 toolchains for both x86_64 and aarch64 architectures.
Allow specifying build targets (gcc11_linux_x86_64, gcc11_linux_aarch64, qcc12_qnx800_x86_64, qcc12_qnx800_aarch64) and build types (Debug, Release).
Provide default build target as gcc11_linux_x86_64.
Source QNX environment automatically when a QNX target is specified.
Improved Compatibility:
Ensures seamless integration and flexibility for building and testing with different toolchains.
Includes fallback mechanisms for missing compilers or tools, with clear error messages.