### PR TITLE
Centralize Logging Macros and Enhance Build Script

### DIFF
--- a/CMake/Toolchain/CMakeLogging/tool_chain_log_config.cmake
+++ b/CMake/Toolchain/CMakeLogging/tool_chain_log_config.cmake
@@ -1,0 +1,296 @@
+# =======================================================================================
+#  OpenAA: Open Source Adaptive AUTOSAR Project
+#  Author: Sherif Mohamed
+#  File: tool_chain_log_config.cmake
+#
+#  Purpose:
+#    - Centralize all logging macros (including log_decorator).
+#    - Dump environment variables, CMake variables, initial flags, final flags, etc.
+#    - Provide a scalable approach for logging across multiple toolchains.
+#    - Includes a "Project Options" section to log all relevant options.
+#
+#  Usage:
+#    Include this file at the END of your toolchain file, for example:
+#      include("tool_chain_log_config.cmake")
+# =======================================================================================
+
+if(TOOLCHAIN_LOGGING_DONE)
+  # Already logged. Exit without redefinition or repeated logs.
+  return()
+endif()
+set(TOOLCHAIN_LOGGING_DONE TRUE CACHE INTERNAL "" FORCE)
+
+# ------------------------------------------------------------------------------
+# 0) Optional “first-run” detection logic
+# ------------------------------------------------------------------------------
+if(NOT FIRST_RUN_COMPLETED AND FIRST_RUN_DETECTED)
+  set(FIRST_RUN_COMPLETED TRUE CACHE INTERNAL "" FORCE)
+  set(FIRST_RUN_DETECTED FALSE CACHE INTERNAL "" FORCE)
+endif()
+set(FIRST_RUN_DETECTED TRUE CACHE INTERNAL "")
+
+# ------------------------------------------------------------------------------
+# 1) Toggle color and verbosity
+# ------------------------------------------------------------------------------
+if(NOT DEFINED ENABLE_LOG_COLORS)
+  set(ENABLE_LOG_COLORS ON)
+endif()
+
+if(NOT DEFINED VERBOSE_TOOLCHAIN_LOG)
+  set(VERBOSE_TOOLCHAIN_LOG OFF)
+endif()
+
+# ------------------------------------------------------------------------------
+# 2) Define color-logging macros
+#    - log_info, log_warn, log_error, log_debug, log_decorator
+#    - We store them here so everything is "centralized" in one place.
+# ------------------------------------------------------------------------------
+string(ASCII 27 ESC_CHAR)
+
+function(_give_shape color text)
+  if(ENABLE_LOG_COLORS)
+    message(STATUS "${ESC_CHAR}[1;${color}m${text}${ESC_CHAR}[0m")
+  else()
+    message(STATUS "${text}")
+  endif()
+endfunction()
+
+macro(log_info msg)
+  # White text
+  _give_shape("37" "[INFO] ${msg}")
+endmacro()
+
+macro(log_warn msg)
+  # Yellow text
+  _give_shape("33" "[WARN] ${msg}")
+endmacro()
+
+macro(log_error msg)
+  # Red text
+  _give_shape("31" "[ERROR] ${msg}")
+endmacro()
+
+macro(log_debug msg)
+  # Cyan text
+  if(VERBOSE_TOOLCHAIN_LOG)
+    _give_shape("36" "[DEBUG] ${msg}")
+  endif()
+endmacro()
+
+macro(log_decorator msg)
+  # Blue text
+  _give_shape("34" "${msg}")
+endmacro()
+
+# ------------------------------------------------------------------------------
+# 3) Distinguish QNX vs. Linux vs. other system
+# ------------------------------------------------------------------------------
+if(CMAKE_SYSTEM_NAME STREQUAL "QNX")
+  log_decorator("====== Target-compiling for QNX ==============================")
+
+  if(DEFINED ENV{QNX_HOST})
+    log_info("QNX_HOST            = $ENV{QNX_HOST}")
+  endif()
+  if(DEFINED ENV{QNX_TARGET})
+    log_info("QNX_TARGET          = $ENV{QNX_TARGET}")
+  endif()
+  if(DEFINED ENV{QNX_CONFIGURATION})
+    log_info("QNX_CONFIGURATION   = $ENV{QNX_CONFIGURATION}")
+  endif()
+
+  if(CMAKE_C_COMPILER_TARGET)
+    log_info("C_COMPILER_TARGET   = ${CMAKE_C_COMPILER_TARGET}")
+  endif()
+  if(CMAKE_CXX_COMPILER_TARGET)
+    log_info("CXX_COMPILER_TARGET = ${CMAKE_CXX_COMPILER_TARGET}")
+  endif()
+
+else()
+  log_decorator("====== Target-compiling for LINUX/OTHER ======================")
+
+  if(CMAKE_SYSTEM_NAME)
+    log_info("PLATFORM_TARGET     = ${CMAKE_SYSTEM_NAME}")
+  endif()
+  if(CMAKE_SYSTEM_PROCESSOR)
+    log_info("Target arch         = ${CMAKE_SYSTEM_PROCESSOR}")
+  endif()
+endif()
+
+# ------------------------------------------------------------------------------
+# 4) General CMake info
+# ------------------------------------------------------------------------------
+log_decorator("================ GENERAL CONFIG =============================")
+log_info("CMAKE_TOOLCHAIN_FILE  : ${CMAKE_TOOLCHAIN_FILE}")
+log_info("CMAKE_VERBOSE_MAKEFILE: ${CMAKE_VERBOSE_MAKEFILE}")
+log_decorator("-------------------------------------------------------------")
+log_info("CMAKE_VERSION         : ${CMAKE_VERSION}")
+log_info("CMAKE_BUILD_TYPE      : ${CMAKE_BUILD_TYPE}")
+log_info("CMAKE_SYSTEM_NAME     : ${CMAKE_SYSTEM_NAME}")
+
+# ------------------------------------------------------------------------------
+# 4a) Fallback logic for compiler versions (if empty)
+# ------------------------------------------------------------------------------
+if(NOT DEFINED CMAKE_C_COMPILER_VERSION OR "${CMAKE_C_COMPILER_VERSION}" STREQUAL "")
+  execute_process(
+    COMMAND "${CMAKE_C_COMPILER}" --version
+    OUTPUT_VARIABLE _c_compiler_out
+    ERROR_VARIABLE  _c_compiler_err
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+  )
+  string(REGEX REPLACE "\n.*" "" _c_compiler_line "${_c_compiler_out}")
+  if(_c_compiler_line STREQUAL "" AND NOT _c_compiler_err STREQUAL "")
+    set(CMAKE_C_COMPILER_VERSION "(unknown, --version leads to error)")
+  else()
+    set(CMAKE_C_COMPILER_VERSION "${_c_compiler_line}")
+  endif()
+endif()
+
+if(NOT DEFINED CMAKE_CXX_COMPILER_VERSION OR "${CMAKE_CXX_COMPILER_VERSION}" STREQUAL "")
+  execute_process(
+    COMMAND "${CMAKE_CXX_COMPILER}" --version
+    OUTPUT_VARIABLE _cxx_compiler_out
+    ERROR_VARIABLE  _cxx_compiler_err
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+  )
+  string(REGEX REPLACE "\n.*" "" _cxx_compiler_line "${_cxx_compiler_out}")
+  if(_cxx_compiler_line STREQUAL "" AND NOT _cxx_compiler_err STREQUAL "")
+    set(CMAKE_CXX_COMPILER_VERSION "(unknown, --version leads to error)")
+  else()
+    set(CMAKE_CXX_COMPILER_VERSION "${_cxx_compiler_line}")
+  endif()
+endif()
+
+if(CMAKE_C_COMPILER)
+  log_info("C Compiler used       : ${CMAKE_C_COMPILER}")
+endif()
+if(CMAKE_C_COMPILER_VERSION)
+  log_info("C Compiler version    : ${CMAKE_C_COMPILER_VERSION}")
+endif()
+
+if(CMAKE_CXX_COMPILER)
+  log_info("CXX Compiler used     : ${CMAKE_CXX_COMPILER}")
+endif()
+if(CMAKE_CXX_COMPILER_VERSION)
+  log_info("CXX Compiler version  : ${CMAKE_CXX_COMPILER_VERSION}")
+endif()
+
+# If you want to show the standard, do so here (if they are set)
+if(CMAKE_C_STANDARD)
+  log_info("C Standard used       : ${CMAKE_C_STANDARD}")
+endif()
+if(CMAKE_CXX_STANDARD)
+  log_info("CXX Standard used     : ${CMAKE_CXX_STANDARD}")
+endif()
+
+# ------------------------------------------------------------------------------
+# 5) _INIT Variables from the -C file
+# ------------------------------------------------------------------------------
+log_decorator("====== _INIT VARIABLES FROM -C FILE (if any) ================")
+
+macro(log_init_variable var)
+  if(DEFINED ${var})
+    log_info("${var}: ${${var}}")
+  endif()
+endmacro()
+
+# For C Flags:
+log_init_variable("CMAKE_C_FLAGS_INIT")
+log_init_variable("CMAKE_C_FLAGS_DEBUG_INIT")
+log_init_variable("CMAKE_C_FLAGS_RELEASE_INIT")
+log_init_variable("CMAKE_C_FLAGS_MINSIZEREL_INIT")
+log_init_variable("CMAKE_C_FLAGS_RELWITHDEBINFO_INIT")
+log_init_variable("CMAKE_C_FLAGS_ALSAN_INIT")
+log_init_variable("CMAKE_C_FLAGS_TSAN_INIT")
+log_init_variable("CMAKE_C_FLAGS_UBSAN_INIT")
+
+# For C++ Flags:
+log_init_variable("CMAKE_CXX_FLAGS_INIT")
+log_init_variable("CMAKE_CXX_FLAGS_DEBUG_INIT")
+log_init_variable("CMAKE_CXX_FLAGS_RELEASE_INIT")
+log_init_variable("CMAKE_CXX_FLAGS_MINSIZEREL_INIT")
+log_init_variable("CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT")
+log_init_variable("CMAKE_CXX_FLAGS_ALSAN_INIT")
+log_init_variable("CMAKE_CXX_FLAGS_TSAN_INIT")
+log_init_variable("CMAKE_CXX_FLAGS_UBSAN_INIT")
+
+# For linker flags, if your -C file sets them:
+log_init_variable("CMAKE_EXE_LINKER_FLAGS_INIT")
+log_init_variable("CMAKE_MODULE_LINKER_FLAGS_INIT")
+log_init_variable("CMAKE_SHARED_LINKER_FLAGS_INIT")
+log_init_variable("CMAKE_STATIC_LINKER_FLAGS_INIT")
+
+# ------------------------------------------------------------------------------
+# 6) EFFECTIVE FLAGS
+# ------------------------------------------------------------------------------
+log_decorator("====== IN ACTION CMAKE FLAGS ================================")
+log_info("CMAKE_C_FLAGS                   : ${CMAKE_C_FLAGS}")
+log_info("CMAKE_CXX_FLAGS                 : ${CMAKE_CXX_FLAGS}")
+log_decorator("-------------------------------------------------------------")
+log_info("CMAKE_C_FLAGS_DEBUG             : ${CMAKE_C_FLAGS_DEBUG}")
+log_info("CMAKE_C_FLAGS_RELEASE           : ${CMAKE_C_FLAGS_RELEASE}")
+log_info("CMAKE_C_FLAGS_MINSIZEREL        : ${CMAKE_C_FLAGS_MINSIZEREL}")
+log_info("CMAKE_C_FLAGS_RELWITHDEBINFO    : ${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+log_decorator("-------------------------------------------------------------")
+log_info("CMAKE_CXX_FLAGS_DEBUG           : ${CMAKE_CXX_FLAGS_DEBUG}")
+log_info("CMAKE_CXX_FLAGS_RELEASE         : ${CMAKE_CXX_FLAGS_RELEASE}")
+log_info("CMAKE_CXX_FLAGS_MINSIZEREL      : ${CMAKE_CXX_FLAGS_MINSIZEREL}")
+log_info("CMAKE_CXX_FLAGS_RELWITHDEBINFO  : ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+log_decorator("-------------------------------------------------------------")
+log_info("CMAKE_EXE_LINKER_FLAGS          : ${CMAKE_EXE_LINKER_FLAGS}")
+log_info("CMAKE_MODULE_LINKER_FLAGS       : ${CMAKE_MODULE_LINKER_FLAGS}")
+log_info("CMAKE_SHARED_LINKER_FLAGS       : ${CMAKE_SHARED_LINKER_FLAGS}")
+log_info("CMAKE_STATIC_LINKER_FLAGS       : ${CMAKE_STATIC_LINKER_FLAGS}")
+log_decorator("-------------------------------------------------------------")
+
+# ------------------------------------------------------------------------------
+# 7) PROJECT OPTIONS SECTION
+# ------------------------------------------------------------------------------
+log_decorator("=================== PROJECT OPTIONS =========================")
+
+macro(log_option var)
+  if(DEFINED ${var})
+    log_info("option -D${var}=${${var}}")
+  else()
+    log_info("option -D${var}= (not defined)")
+  endif()
+endmacro()
+
+# Example project options to log:
+log_option("ENABLE_PROFILING")
+log_option("ENABLE_STRICT")
+log_option("ENABLE_SANITIZER")
+log_option("ENABLE_SANITIZER_RECOVER")
+log_option("ENABLE_COMPILE_TIME_TRACE")
+log_option("ENABLE_SYNTAX_ONLY")
+log_option("RUN_CLANG_TIDY_ENABLE")
+log_option("BUILD_TESTS")
+log_option("ENABLE_DOXYGEN")
+log_option("ENABLE_EXCEPTIONS")
+log_option("ENABLE_RTTI")
+log_option("ENABLE_CCACHE")
+log_option("ENABLE_SCCACHE")
+log_option("DEBUG_LEVEL")
+log_option("OPTIMIZATION_LEVEL")
+log_option("ENABLE_SPLIT_DWARF")
+log_option("BUILD_TEST2020")
+log_option("VERBOSE_TOOLCHAIN_LOG")
+log_option("CACHE_ALL_FLAG_VARS")
+log_option("ENABLE_COLOR")
+log_option("SET_LINKER")
+
+log_decorator("=============================================================")
+
+# ------------------------------------------------------------------------------
+# 8) Optional: Dump ALL cache variables
+# ------------------------------------------------------------------------------
+if(VERBOSE_TOOLCHAIN_LOG)
+  log_decorator("====== ALL CACHE VARIABLES (VERBOSE) ========================")
+  get_cmake_property(_cacheVars CACHE_VARIABLES)
+  foreach(_cv ${_cacheVars})
+    get_property(_val CACHE "${_cv}" PROPERTY VALUE)
+    log_debug(" [${_cv}] = ${_val}")
+  endforeach()
+  log_decorator("=============================================================")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,3 +59,5 @@ endif()
 # Explicitly set the C++ compiler to g++ or another compiler if needed
 # Uncomment and set if you want to enforce a specific compiler
 # set(CMAKE_CXX_COMPILER "g++")
+
+include("${CMAKE_CURRENT_LIST_DIR}/CMake/Toolchain/CMakeLogging/tool_chain_log_config.cmake")

--- a/build.sh
+++ b/build.sh
@@ -1,225 +1,284 @@
 #!/bin/bash
-
-#[=======================================================================[
-# OpenAA: Open Source Adaptive AUTOSAR Project
-# Author: Sherif Mohamed
 #
-# File description:
-# -----------------
-# Functional programming style build script for AdaptiveAutosarCpp17.
-# Integrates:
-# - CMakePresets.json for build presets.
-# - Configuration file (-C option) for initial cache variables.
-# - Logging utility for better traceability.
-# - Modular, functional programming style for maintainability.
-#]=======================================================================]
+# [=========================================================================]
+#  OpenAA: Open Source Adaptive AUTOSAR Project
+#  Author: Sherif Mohamed
+#
+#  File description:
+#  -----------------
+#  build script for AdaptiveAutosarCpp17, with error handling,
+#  standardized structure, and detailed commentary.
+#
+#  Integrations:
+#  - CMakePresets.json for build presets.
+#  - Configuration file (-C option) for initial cache variables.
+#  - Logging utility for better traceability.
+#  - Modular, functional programming style for maintainability.
+#
+#  Usage:
+#    ./build.sh [options]
+#    e.g.: ./build.sh --clean --build-type Release --build-target qcc12_qnx800_aarch64
+# [=========================================================================]
 
-#****************************************************************************************************
-# Script Configuration
-#****************************************************************************************************
+# ------------------------------------------------------------------------------
+# 1) Bash Settings for Safety
+# ------------------------------------------------------------------------------
+set -e          # Exit immediately if any command returns non-zero status.
+set -o pipefail # If any command in a pipeline fails, the entire pipeline fails.
 
-set -e  # Exit on error
+# ------------------------------------------------------------------------------
+# 2) Default Build Options
+# ------------------------------------------------------------------------------
+BUILD_TYPE="Release"                   # Default build type
+BUILD_TARGET="gcc11_linux_x86_64"      # Default build target
+NUM_JOBS=$(nproc)                      # Default to number of CPU cores
+CLEAN_BUILD=false                      # Default: do not clean
+SDP_PATH=""                            # Default: no QNX SDP path
+PRESET_NAME=""                         # Computed build preset name
+CONFIG_FILE=""                         # Computed config file path
 
-# Default build options
-BUILD_TYPE="Release"                 # Default build type
-BUILD_TARGET="gcc11_linux_x86_64"    # Default build target
-NUM_JOBS=$(nproc)                    # Default to number of CPU cores
-CLEAN_BUILD=false                    # Default: no clean build
-SDP_PATH=""                          # Default: no QNX SDP path
-PRESET_NAME=""                       # Preset name based on build type and target
-CONFIG_FILE=""                       # Config file path
-
-#****************************************************************************************************
-# Logging Utility
-#****************************************************************************************************
-
+# ------------------------------------------------------------------------------
+# 3) Logging Utility
+# ------------------------------------------------------------------------------
 log() {
     local level=$1
     local message=$2
     local timestamp=$(date "+%Y-%m-%d %H:%M:%S")
     case $level in
-        INFO) echo -e "\033[32m[INFO] [$timestamp] $message\033[0m" ;;
+        INFO) echo -e "\033[37m[INFO] [$timestamp] $message\033[0m" ;;
         WARN) echo -e "\033[33m[WARN] [$timestamp] $message\033[0m" ;;
         ERROR) echo -e "\033[31m[ERROR] [$timestamp] $message\033[0m" ;;
         *) echo "[UNKNOWN] [$timestamp] $message" ;;
     esac
 }
 
-#****************************************************************************************************
-# Functions
-#****************************************************************************************************
 
-# Function to display usage information
+# ------------------------------------------------------------------------------
+# 4) Error Handling with run_command
+# ------------------------------------------------------------------------------
+# This function runs a given command (as an array), logs it, and checks status.
+# If the command fails (non-zero exit), we log an error and exit.
+# ------------------------------------------------------------------------------
+run_command() {
+  local cmd=("$@") # capture all arguments as an array
+  log INFO "Running command: ${cmd[*]}"
+  
+  # Use bash 'command' builtin to run safely
+  "${cmd[@]}"
+  local status=$?
+  
+  if [ $status -ne 0 ]; then
+    log ERROR "Command failed with exit code $status: ${cmd[*]}"
+    exit $status
+  fi
+}
+
+# ------------------------------------------------------------------------------
+# 5) Usage / Help
+# ------------------------------------------------------------------------------
 usage() {
-    log INFO "Usage: $0 [OPTIONS]"
-    echo ""
-    echo "Options:"
-    echo "  -h, --help                Show this help message and exit"
-    echo "  -c, --clean               Perform a clean build by removing build and install directories"
-    echo "  -t, --build-type TYPE     Specify build type (Debug, Release). Default: Release"
-    echo "  -j, --jobs N              Specify number of parallel jobs. Default: number of CPU cores"
-    echo "  -b, --build-target TARGET Specify build target (gcc11_linux_x86_64, gcc11_linux_aarch64, qcc12_qnx_aarch64, qcc12_qnx_x86_64)"
-    echo "  -s, --sdp-path PATH       Specify the path to qnxsdp-env.sh for QNX builds"
-    echo ""
-    exit 1
+  log INFO "Usage: $0 [OPTIONS]"
+  echo ""
+  echo "Options:"
+  echo "  -h, --help                Show this help message and exit"
+  echo "  -c, --clean               Perform a clean build by removing build and install directories"
+  echo "  -t, --build-type TYPE     Specify build type (Debug, Release, etc.). Default: Release"
+  echo "  -j, --jobs N              Specify number of parallel jobs. Default: number of CPU cores"
+  echo "  -b, --build-target TARGET Specify build target (e.g. gcc11_linux_x86_64, qcc12_qnx800_aarch64, etc.)"
+  echo "  -s, --sdp-path PATH       Specify path to qnxsdp-env.sh for QNX builds"
+  echo ""
+  exit 1
 }
 
-# Function to handle cleanup on interruption
+# ------------------------------------------------------------------------------
+# 6) Cleanup on Interruption
+# ------------------------------------------------------------------------------
 cleanup() {
-    log WARN "Build interrupted. Cleaning up..."
-    exit 1
+  log WARN "Build interrupted by user or signal. Cleaning up..."
+  # If you have any partial files or locks to remove, do it here.
+  exit 1
 }
 
-# Function to source QNX environment if required
+# ------------------------------------------------------------------------------
+# 7) Setup QNX Environment (if needed)
+# ------------------------------------------------------------------------------
 setup_environment() {
-    if [[ "$BUILD_TARGET" == qcc12_qnx_aarch64 || "$BUILD_TARGET" == qcc12_qnx_x86_64 ]]; then
-        if [ -z "$SDP_PATH" ]; then
-            log ERROR "SDP path must be provided for QNX builds."
-            exit 1
-        fi
-        log INFO "Sourcing QNX SDP environment from: $SDP_PATH"
-        source "$SDP_PATH"
+  # If user chose a QNX target, we require an SDP path.
+  if [[ "$BUILD_TARGET" == qcc12_qnx800_aarch64 || "$BUILD_TARGET" == qcc12_qnx800_x86_64 ]]; then
+    if [ -z "$SDP_PATH" ]; then
+      log ERROR "SDP path must be provided for QNX builds."
+      exit 1
     fi
+    log INFO "Sourcing QNX SDP environment from: $SDP_PATH"
+    source "$SDP_PATH"
+  fi
 }
 
-# Function to define build parameters based on target and type
+# ------------------------------------------------------------------------------
+# 8) Define Build Parameters Based on Target + Build Type
+# ------------------------------------------------------------------------------
 define_build_parameters() {
-    case $BUILD_TARGET in
-        gcc11_linux_x86_64)
-            if [ "$BUILD_TYPE" == "Debug" ]; then
-                PRESET_NAME="gcc11_linux_x86_64_debug"
-            else
-                PRESET_NAME="gcc11_linux_x86_64_release"
-            fi
-            CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
-            ;;
-        gcc11_linux_aarch64)
-            if [ "$BUILD_TYPE" == "Debug" ]; then
-                PRESET_NAME="gcc11_linux_aarch64_debug"
-            else
-                PRESET_NAME="gcc11_linux_aarch64_release"
-            fi
-            CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
-            ;;
-        qcc12_qnx_aarch64)
-            if [ "$BUILD_TYPE" == "Debug" ]; then
-                PRESET_NAME="qcc12_qnx800_aarch64_debug"
-            else
-                PRESET_NAME="qcc12_qnx800_aarch64_release"
-            fi
-            CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
-            ;;
-        qcc12_qnx_x86_64)
-            if [ "$BUILD_TYPE" == "Debug" ]; then
-                PRESET_NAME="qcc12_qnx800_x86_64_debug"
-            else
-                PRESET_NAME="qcc12_qnx800_x86_64_release"
-            fi
-            CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
-            ;;
-        *)
-            log ERROR "Invalid build target: $BUILD_TARGET"
-            usage
-            ;;
-    esac
+  case $BUILD_TARGET in
+    gcc11_linux_x86_64)
+      if [ "$BUILD_TYPE" == "Debug" ]; then
+        PRESET_NAME="gcc11_linux_x86_64_debug"
+      else
+        PRESET_NAME="gcc11_linux_x86_64_release"
+      fi
+      CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
+      ;;
+    gcc11_linux_aarch64)
+      if [ "$BUILD_TYPE" == "Debug" ]; then
+        PRESET_NAME="gcc11_linux_aarch64_debug"
+      else
+        PRESET_NAME="gcc11_linux_aarch64_release"
+      fi
+      CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
+      ;;
+    qcc12_qnx800_aarch64)
+      if [ "$BUILD_TYPE" == "Debug" ]; then
+        PRESET_NAME="qcc12_qnx800_aarch64_debug"
+      else
+        PRESET_NAME="qcc12_qnx800_aarch64_release"
+      fi
+      CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
+      ;;
+    qcc12_qnx800_x86_64)
+      if [ "$BUILD_TYPE" == "Debug" ]; then
+        PRESET_NAME="qcc12_qnx800_x86_64_debug"
+      else
+        PRESET_NAME="qcc12_qnx800_x86_64_release"
+      fi
+      CONFIG_FILE="CMake/CMakeConfig/$PRESET_NAME.cmake"
+      ;;
+    *)
+      log ERROR "Invalid build target: $BUILD_TARGET"
+      usage
+      ;;
+  esac
 }
 
-# Function to clean build and install directories if requested
+# ------------------------------------------------------------------------------
+# 9) Clean Build & Install Directories (if --clean was passed)
+# ------------------------------------------------------------------------------
 clean_directories() {
-    if [ "$CLEAN_BUILD" = true ]; then
-        local build_dir="${PWD}/build/${PRESET_NAME}"
-        local install_dir="${PWD}/install/${PRESET_NAME}"
-        log INFO "Cleaning build directory: $build_dir"
-        rm -rf "$build_dir"
-        log INFO "Cleaning install directory: $install_dir"
-        rm -rf "$install_dir"
-    fi
-}
-
-# Function to configure the project using CMake
-configure_project() {
-    if [ -f "$CONFIG_FILE" ]; then
-        log INFO "Using configuration file: $CONFIG_FILE"
-        cmake -C "$CONFIG_FILE" --preset "$PRESET_NAME"
-    else
-        log WARN "Configuration file not found: $CONFIG_FILE. Proceeding without it."
-        cmake --preset "$PRESET_NAME"
-    fi
-}
-
-# Function to build the project
-build_project() {
-    local build_dir="${PWD}/build/${PRESET_NAME}"
-    log INFO "Building the project in: $build_dir"
-    cmake --build "$build_dir" -- -j"$NUM_JOBS"
-}
-
-# Function to install the project
-install_project() {
+  if [ "$CLEAN_BUILD" = true ]; then
     local build_dir="${PWD}/build/${PRESET_NAME}"
     local install_dir="${PWD}/install/${PRESET_NAME}"
-    log INFO "Installing the project to: $install_dir"
-    cmake --install "$build_dir" --prefix "$install_dir"
+
+    log INFO "Cleaning build directory: $build_dir"
+    rm -rf "$build_dir"
+
+    log INFO "Cleaning install directory: $install_dir"
+    rm -rf "$install_dir"
+  fi
 }
 
-#****************************************************************************************************
-# Main Function
-#****************************************************************************************************
+# ------------------------------------------------------------------------------
+# 10) Configure Project (cmake)
+# ------------------------------------------------------------------------------
+configure_project() {
+  # Verify cmake is installed and working
+  if ! command -v cmake &>/dev/null; then
+    log ERROR "cmake command not found. Please install cmake or fix your PATH."
+    exit 1
+  fi
 
+  if [ -f "$CONFIG_FILE" ]; then
+    log INFO "Using configuration file: $CONFIG_FILE"
+    run_command cmake -C "$CONFIG_FILE" --preset "$PRESET_NAME"
+  else
+    if [ -n "$CONFIG_FILE" ]; then
+      log WARN "Configuration file not found: $CONFIG_FILE. Proceeding without it."
+    fi
+    run_command cmake --preset "$PRESET_NAME"
+  fi
+}
+
+# ------------------------------------------------------------------------------
+# 11) Build Project
+# ------------------------------------------------------------------------------
+build_project() {
+  local build_dir="${PWD}/build/${PRESET_NAME}"
+  log INFO "Building the project in: $build_dir"
+
+  # If you wanted to log or check anything prior to building, do it here.
+  run_command cmake --build "$build_dir" -- -j"$NUM_JOBS"
+}
+
+# ------------------------------------------------------------------------------
+# 12) Install Project
+# ------------------------------------------------------------------------------
+install_project() {
+  local build_dir="${PWD}/build/${PRESET_NAME}"
+  local install_dir="${PWD}/install/${PRESET_NAME}"
+
+  log INFO "Installing the project to: $install_dir"
+  run_command cmake --install "$build_dir" --prefix "$install_dir"
+}
+
+# ------------------------------------------------------------------------------
+# 13) Main Function
+# ------------------------------------------------------------------------------
 main() {
-    # Trap signals for cleanup on interruption
-    trap cleanup SIGINT SIGTERM
+  # Trap signals for cleanup if user presses Ctrl+C, etc.
+  trap cleanup SIGINT SIGTERM
 
-    # Parse command-line arguments
-    while [[ "$#" -gt 0 ]]; do
-        case $1 in
-            -h|--help)
-                usage
-                ;;
-            -c|--clean)
-                CLEAN_BUILD=true
-                ;;
-            -t|--build-type)
-                BUILD_TYPE="$2"
-                shift
-                ;;
-            -j|--jobs)
-                NUM_JOBS="$2"
-                shift
-                ;;
-            -b|--build-target)
-                BUILD_TARGET="$2"
-                shift
-                ;;
-            -s|--sdp-path)
-                SDP_PATH="$2"
-                shift
-                ;;
-            *)
-                log ERROR "Unknown option: $1"
-                usage
-                ;;
-        esac
+  # Parse command-line arguments
+  while [[ "$#" -gt 0 ]]; do
+    case $1 in
+      -h|--help)
+        usage
+        ;;
+      -c|--clean)
+        CLEAN_BUILD=true
+        ;;
+      -t|--build-type)
+        BUILD_TYPE="$2"
         shift
-    done
+        ;;
+      -j|--jobs)
+        NUM_JOBS="$2"
+        shift
+        ;;
+      -b|--build-target)
+        BUILD_TARGET="$2"
+        shift
+        ;;
+      -s|--sdp-path)
+        SDP_PATH="$2"
+        shift
+        ;;
+      *)
+        log ERROR "Unknown option: $1"
+        usage
+        ;;
+    esac
+    shift
+  done
 
-    # Setup environment and define parameters
-    setup_environment
-    define_build_parameters
+  # 1) Setup environment
+  setup_environment
 
-    # Clean directories if needed
-    clean_directories
+  # 2) Define build parameters (preset name, config file path, etc.)
+  define_build_parameters
 
-    # Configure, build, and install the project
-    configure_project
-    build_project
-    install_project
+  # 3) Clean if requested
+  clean_directories
 
-    log INFO "Build completed successfully."
+  # 4) Configure (cmake)
+  configure_project
+
+  # 5) Build
+  build_project
+
+  # 6) Install
+  install_project
+
+  log INFO "Build completed successfully."
 }
 
-#****************************************************************************************************
-# Execute Main Function
-#****************************************************************************************************
-
+# ------------------------------------------------------------------------------
+# 14) Execute Main
+# ------------------------------------------------------------------------------
 main "$@"


### PR DESCRIPTION
Centralized Logging Macros

Created a unified tool_chain_log_config.cmake that houses all color-logging macros (log_info, log_warn, log_error, log_debug, log_decorator).
Switched INFO logs to white text for a more standard, user-friendly experience.
Ensured logs only appear once by guarding with TOOLCHAIN_LOGGING_DONE.
Enhanced Build Script

Implemented better error handling with pipefail and a new run_command wrapper that logs commands and checks exit codes.
Added detailed comments throughout for maintainability and clarity.
Provided robust signals handling with a cleanup function on interruption.
Together, these changes improve our maintainability, clarity, and developer experience when cross-compiling for QNX or other platforms. They also unify the color-coded output so that debugging and daily usage are more straightforward for the team.