### PR TITLE
Fix the over-written of the CMake config by the safety level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,9 +52,12 @@ if(POLICY CMP0177)
     cmake_policy(SET CMP0177 NEW)
 endif()
 
-# Additional policy examples (optional):
-#   if(POLICY CMP0079) ...
-#   if(POLICY CMP0048) ...
+if(DEFINED ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS)
+  message(STATUS "Conditional exceptions flag is enabled: ${ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS}")
+  # Add it as a compile definition to all targets:
+  add_compile_definitions(ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS)
+endif()
+
 
 # -------------------------------------------------------------------------------------------------
 # Subdirectories for main libraries/components

--- a/build.sh
+++ b/build.sh
@@ -234,21 +234,33 @@ configure_project() {
     exit 1
   fi
 
-  # Generate temporary config.cmake for exception safety
-  generate_temp_config
-
   log INFO "Configuring the project with preset: $PRESET_NAME and EXCEPTION_SAFETY_MODE=${EXCEPTION_SAFETY_MODE}"
-  
+
+  # Build an array of cmake command arguments.
+  cmd=(cmake)
+
+  # If a configuration file exists, add it.
   if [ -f "$CONFIG_FILE" ]; then
     log INFO "Using configuration file: $CONFIG_FILE"
-    run_command cmake -C "$CONFIG_FILE" -C "$TEMP_CACHE_FILE" --preset "$PRESET_NAME"
+    cmd+=("-C" "$CONFIG_FILE")
   else
     if [ -n "$CONFIG_FILE" ]; then
       log WARN "Configuration file not found: $CONFIG_FILE. Proceeding without it."
     fi
-    run_command cmake -C "$TEMP_CACHE_FILE" --preset "$PRESET_NAME"
   fi
+
+  # Conditionally add the conditional exceptions flag if the mode is "conditional".
+  if [ "$EXCEPTION_SAFETY_MODE" = "conditional" ]; then
+    cmd+=("-DARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS=1")
+  fi
+
+  # Specify the preset.
+  cmd+=("--preset" "$PRESET_NAME")
+
+  # Run the command.
+  run_command "${cmd[@]}"
 }
+
 
 # ------------------------------------------------------------------------------
 # 12) Build Project

--- a/components/open-aa-platform-os-abstraction-libs/src/ara/os/qnx/process/process.cpp
+++ b/components/open-aa-platform-os-abstraction-libs/src/ara/os/qnx/process/process.cpp
@@ -40,7 +40,8 @@ namespace process {
  * \note   This method avoids exceptions and uses safe string operations to prevent buffer overflows.
  */
 auto ProcessInteractionImpl::GetProcessName(char* buffer, std::size_t bufferSize) const noexcept -> ara::os::interface::process::ErrorCode {
-
+    static_cast<void>(buffer);
+    static_cast<void>(bufferSize);
     return ara::os::interface::process::ErrorCode::NullBuffer;
 }
 


### PR DESCRIPTION
Make the exception option to be passed through CMake command instead