### PR TITLE
Make ara::core::Array fully tuple-like

### DIFF
--- a/components/open-aa-std-adaptive-autosar-libs/include/ara/core/array.h
+++ b/components/open-aa-std-adaptive-autosar-libs/include/ara/core/array.h
@@ -51,31 +51,6 @@
 
 
 /**********************************************************************************************************************
- *  SECTION: Forward Declaration
- *********************************************************************************************************************/
-namespace ara::core {
-/*!
- * \brief  Forward declaration of the get function template.
- */
-template <std::size_t I, typename T, std::size_t N>
-constexpr auto get(ara::core::Array<T,N>&) noexcept -> T&;
-
-/*!
- * \brief  Forward declaration of the get function template.
- */
-template <std::size_t I, typename T, std::size_t N>
-constexpr auto get(const ara::core::Array<T,N>&) noexcept -> const T&;
-
-/*!
- * \brief  Forward declaration of the get function template.
- */
-template <std::size_t I, typename T, std::size_t N>
-constexpr auto get(ara::core::Array<T,N>&&) noexcept -> T&&;
-
-} // namespace ara::core
-
-
-/**********************************************************************************************************************
  *  TUPLE: INTERFACE SPECIALISATIONS
  *  ---------------------------------------------------------------------------------------------------------------
  *  std::tuple_size          [SWS_CORE_01280]
@@ -152,7 +127,67 @@ namespace std {
         using type = T;                         // every element is T
     };
 } // namespace std
- 
+
+
+/**********************************************************************************************************************
+ *  TUPLE-LIKE UTILITIES
+ *  ---------------------------------------------------------------------------------------------------------------
+ *  ara::core::apply      – constexpr replacement for std::apply that works with ADL
+ *  ara::core::tuple_cat  – concatenates any number of tuple-protocol objects
+ *********************************************************************************************************************/
+namespace ara {
+namespace core {
+
+/**********************************************************************************************************************
+ *  ara::core::apply
+ *********************************************************************************************************************/
+/*! 
+ * \brief  Applies a callable to the elements of a tuple-like object.
+ *
+ * \details
+ * - This function is a constexpr replacement for std::apply that works with ADL.
+ * - It forwards the callable and the tuple-like object, expanding the tuple-like object's elements as arguments to the callable.
+ *
+ * \tparam F     The type of the callable (function, lambda, etc.).
+ * \tparam Tuple The type of the tuple-like object.
+ * \param f   The callable to apply.
+ * \param tup The tuple-like object containing the elements to pass to the callable.
+ * \return    The result of calling f with the unpacked elements of tup.
+ */
+template<typename F, typename Tuple,
+         typename = std::enable_if_t<
+             detail::is_tuple_like_v<std::remove_reference_t<Tuple>>>>
+constexpr decltype(auto) apply(F&& f, Tuple&& tup)
+{
+    constexpr std::size_t N =
+        std::tuple_size_v<std::remove_cv_t<std::remove_reference_t<Tuple>>>;
+    return detail::apply_impl(std::forward<F>(f),
+                              std::forward<Tuple>(tup),
+                              std::make_index_sequence<N>{});
+}
+
+/*!
+ * \brief  Concatenates any number of tuple-like objects into a single std::tuple.
+ *
+ * \details
+ * - This function concatenates any number of tuple-like objects into a single std::tuple.
+ * - It uses detail::to_std_tuple to convert each tuple-like object to a std::tuple before concatenation.
+ *
+ * \tparam Tuples The types of the tuple-like objects to concatenate.
+ * \param tpls   The tuple-like objects to concatenate.
+ * \return       A std::tuple containing all elements from the input tuple-like objects.
+ */
+template<typename... Tuples,
+         typename = std::enable_if_t<
+             (detail::is_tuple_like_v<std::remove_reference_t<Tuples>> && ... )>>
+constexpr auto tuple_cat(Tuples&&... tpls)
+{
+    return std::tuple_cat( detail::to_std_tuple(std::forward<Tuples>(tpls))... );
+}
+
+} // namespace core
+} // namespace ara
+
 
 /**********************************************************************************************************************
  *  NAMESPACE: ara::core

--- a/components/open-aa-std-adaptive-autosar-libs/include/ara/core/internal/utility.h
+++ b/components/open-aa-std-adaptive-autosar-libs/include/ara/core/internal/utility.h
@@ -30,6 +30,24 @@ namespace ara::core {
 template <typename T, std::size_t N>
 class Array;    
 
+/*!
+ * \brief  Forward declaration of the get function template.
+ */
+template <std::size_t I, typename T, std::size_t N>
+constexpr auto get(ara::core::Array<T,N>&) noexcept -> T&;
+
+/*!
+ * \brief  Forward declaration of the get function template.
+ */
+template <std::size_t I, typename T, std::size_t N>
+constexpr auto get(const ara::core::Array<T,N>&) noexcept -> const T&;
+
+/*!
+ * \brief  Forward declaration of the get function template.
+ */
+template <std::size_t I, typename T, std::size_t N>
+constexpr auto get(ara::core::Array<T,N>&&) noexcept -> T&&;
+
 } // namespace ara::core
 
 
@@ -107,6 +125,90 @@ inline std::mutex g_abortMutex{};
     #else
         return false;                                     // fallback: always run-time
     #endif
+}
+
+
+/***********************************************************************************************************************
+ *  INTERNAL: IS_TUPLE_LIKE
+ ***********************************************************************************************************************/
+/*!
+ * \brief  Trait to detect if a type is tuple-like.
+ *
+ * This trait checks if the type T has a valid std::tuple_size specialization,
+ * indicating that it behaves like a tuple.
+ *
+ * \tparam T The type to check.
+ */
+template<typename T, typename = void>
+struct is_tuple_like : std::false_type {};
+
+template<typename T>
+struct is_tuple_like<T,
+        std::void_t< decltype(std::tuple_size<std::remove_cv_t<T>>::value) >>
+      : std::true_type {};
+
+template<typename T>
+inline constexpr bool is_tuple_like_v = is_tuple_like<T>::value;
+
+
+/*!
+ * \brief  Converts a tuple-like type to a std::tuple.
+ *
+ * This function template converts a tuple-like type (e.g., ara::core::Array)
+ * into a std::tuple, preserving the types of its elements.
+ *
+ * \tparam Src The source tuple-like type to convert.
+ * \param src The source tuple-like object to convert.
+ * \return A std::tuple containing the elements of the source object.
+ */
+template<typename Src, std::size_t... I>
+constexpr auto to_std_tuple_impl(Src&& src, std::index_sequence<I...>)
+{
+    /* unqualified get -> ADL; NO ‘using std::get;’ */
+    return std::tuple< std::decay_t<decltype(get<I>(src))>... >{
+               get<I>(std::forward<Src>(src))... };
+}
+
+/*!
+ * \brief  Converts a tuple-like type to a std::tuple.
+ *
+ * This function template converts a tuple-like type (e.g., ara::core::Array)
+ * into a std::tuple, preserving the types of its elements.
+ *
+ * \tparam Src The source tuple-like type to convert.
+ * \param src The source tuple-like object to convert.
+ * \return A std::tuple containing the elements of the source object.
+ */
+template<typename Src>
+constexpr auto to_std_tuple(Src&& src)
+{
+    constexpr std::size_t N =
+        std::tuple_size_v<std::remove_cv_t<std::remove_reference_t<Src>>>;
+    return to_std_tuple_impl(std::forward<Src>(src),
+                             std::make_index_sequence<N>{});
+}
+
+/*!
+ * \brief  Helper function to apply a callable to the elements of a tuple-like object.
+ *
+ * This function forwards the callable and the tuple-like object, expanding the
+ * tuple-like object's elements as arguments to the callable.
+ *
+ * \tparam F     The type of the callable (function, lambda, etc.).
+ * \tparam Tuple The type of the tuple-like object.
+ * \tparam I     The index sequence for unpacking the tuple-like object's elements.
+ *
+ * \param f   The callable to apply.
+ * \param tup The tuple-like object containing the elements to pass to the callable.
+ * \return    The result of calling f with the unpacked elements of tup.
+ */
+template<typename F, typename Tuple, std::size_t... I>
+constexpr decltype(auto) apply_impl(F&& f,
+                                    Tuple&& tup,
+                                    std::index_sequence<I...>)
+{
+    /* again: unqualified get – ADL only */
+    return std::forward<F>(f)( get<I>(std::forward<Tuple>(tup))... );
 }
 
 /*!

--- a/open-aa-tests/core_platform/core_array_test/ara_core_array.cpp
+++ b/open-aa-tests/core_platform/core_array_test/ara_core_array.cpp
@@ -1267,31 +1267,35 @@ void TestTupleInterface()
     }
 
     /*---------------------------------------------------*
-     * 6. std::apply                                     *
+     * 6. variadic-sum with ara::core::apply              *
      *---------------------------------------------------*/
-    // {
-    //     // sum all elements at compile time
-    //     constexpr int sum = std::apply(
-    //         [](int x, int y, int z){ return x + y + z; },
-    //         ca
-    //     );
-    //     static_assert(sum == 6, "std::apply sum failed");
-    // }
-
+    {
+        /*  generic lambda: accepts any number of arguments,
+            returns their sum with a fold-expression        */
+        constexpr int sum = ara::core::apply(
+            [](auto... xs) constexpr { return (xs + ...); },
+            ca
+        );
+        static_assert(sum == 6, "variadic sum failed");
+    }
+    
     /*---------------------------------------------------*
-     * 7. std::tuple_cat                                 *
+     * 7. ara::core::tuple_cat                            *
      *---------------------------------------------------*/
-    // {
-    //     using A2 = ara::core::Array<int,2>;
-    //     constexpr A2 cb{ 4, 5 };
-    //     // concatenate two Arrays into a single tuple
-    //     constexpr auto tup = std::tuple_cat(ca, cb);
-    //     static_assert( std::tuple_size_v<decltype(tup)> == 5, "tuple_cat size wrong" );
-    //     // verify individual elements
-    //     assert( std::get<0>(tup) == 1 );
-    //     assert( std::get<3>(tup) == 4 );
-    //     assert( std::get<4>(tup) == 5 );
-    // }
+    {
+        using A2 = ara::core::Array<int,2>;
+        constexpr A2 cb{ 4, 5 };
+    
+        /* concatenate two Arrays into a single tuple */
+        constexpr auto tup = ara::core::tuple_cat(ca, cb);
+        static_assert( std::tuple_size_v<decltype(tup)> == 5,
+                       "tuple_cat size wrong" );
+    
+        /* verify individual elements */
+        static_assert( std::get<0>(tup) == 1 );
+        static_assert( std::get<3>(tup) == 4 );
+        static_assert( std::get<4>(tup) == 5 );
+    }
 
     std::cout << "\n>>> Tuple interface - ALL CHECKS PASSED\n";
 }


### PR DESCRIPTION
* Add ADL-based helpers in array.h
    - ara::core::apply      : C++17 constexpr drop-in for std::apply  
    - ara::core::tuple_cat  : concatenates any tuple-protocol objects  
  Both rely on unqualified get<I>() → work for std::tuple, std::array
  and ara::core::Array without touching std::get.

* Provide generic tuple-conversion + is_tuple_like detection
  (all constexpr / header-only, zero-overhead, no exceptions).

* Remove ‘using std::get’ inside helpers to fix Clang ambiguity.

* Unit test
    - replace fixed 3-arg lambda with variadic fold:
        ara::core::apply([](auto... xs){ return (xs + ...); }, arr)
    - add tuple_cat verification
    - all checks now pass with GCC-13 and Clang-21, -fno-exceptions.

No changes to std::tuple itself; only legal template specialisations in
namespace std remain.  ara::core::Array can now participate in structured
bindings, ADL-friendly apply/cat, and other tuple utilities.