### PR TITLE
ara::core::Byte Implementation

### DIFF
--- a/CMake/Toolchain/CMakeLogging/tool_chain_log_config.cmake
+++ b/CMake/Toolchain/CMakeLogging/tool_chain_log_config.cmake
@@ -295,12 +295,12 @@ else()
   log_info("EXCEPTION_SAFETY_MODE: (not defined)")
 endif()
 
-# Check if ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS is defined in CMAKE_CXX_FLAGS
-string(FIND "${CMAKE_CXX_FLAGS}" "-DARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS=1" macro_pos)
+# Check if ENABLE_PLATFORM_CONDITIONAL_EXCEPTION is defined in CMAKE_CXX_FLAGS
+string(FIND "${CMAKE_CXX_FLAGS}" "-DENABLE_PLATFORM_CONDITIONAL_EXCEPTION=1" macro_pos)
 if(macro_pos GREATER_EQUAL 0)
-  log_info("ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS is defined as 1")
+  log_info("ENABLE_PLATFORM_CONDITIONAL_EXCEPTION is defined as 1")
 else()
-  log_info("ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS is NOT defined")
+  log_info("ENABLE_PLATFORM_CONDITIONAL_EXCEPTION is NOT defined")
 endif()
 
 log_decorator("-------------------------------------------------------------")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,10 +52,10 @@ if(POLICY CMP0177)
     cmake_policy(SET CMP0177 NEW)
 endif()
 
-if(DEFINED ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS)
-  message(STATUS "Conditional exceptions flag is enabled: ${ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS}")
+if(DEFINED ENABLE_PLATFORM_CONDITIONAL_EXCEPTION)
+  message(STATUS "Conditional exceptions flag is enabled: ${ENABLE_PLATFORM_CONDITIONAL_EXCEPTION}")
   # Add it as a compile definition to all targets:
-  add_compile_definitions(ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS)
+  add_compile_definitions(ENABLE_PLATFORM_CONDITIONAL_EXCEPTION)
 endif()
 
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ $ ./build.sh [OPTIONS]
 - **`-s, --sdp-path`**: Path to `qnxsdp-env.sh` for QNX builds.
 - **`-j, --jobs`**: Number of parallel jobs.
 - **`-e, --exception-safety`**: Choose exception safety mode:
-    - `conditional` (default): Defines `ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS`
+    - `conditional` (default): Defines `ENABLE_PLATFORM_CONDITIONAL_EXCEPTION`
     - `safe`: Does not define the macro (safe mode)
 
 ### Example Commands

--- a/build.sh
+++ b/build.sh
@@ -248,7 +248,7 @@ configure_project() {
     fi
 
     if [ "$EXCEPTION_SAFETY_MODE" = "conditional" ]; then
-        cmd+=("-DARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS=1")
+        cmd+=("-DENABLE_PLATFORM_CONDITIONAL_EXCEPTION=1")
     fi
 
     cmd+=("--preset" "$PRESET_NAME")

--- a/components/open-aa-example-apps/demo/app/src/demo/manager/demo_manager.cpp
+++ b/components/open-aa-example-apps/demo/app/src/demo/manager/demo_manager.cpp
@@ -18,10 +18,13 @@
  *  INCLUDES
  *********************************************************************************************************************/
 #include <algorithm>                        // For std::all_of
+#include <atomic>                           // For std::atomic, memory_order
 #include <cstdint>                          // For the std types
-#include <iostream>                         // For the std::cout and cerr
-#include <csignal>                          // For signal Block to handle shutdown
+#include <iostream>                         // For std::cout / std::cerr
+#include <csignal>                          // For signal block / sigwait
 #include <cstring>                          // For std::strerror
+#include <thread>                           // For std::thread
+#include <chrono>                           // For steady_clock timing
 
 #include "ara/core/array.h"                 // For platform core Array class
 #include "ara/core/abort.h"
@@ -33,11 +36,11 @@ namespace manager {
 /** -------------------------------------------------------------------------------------------------------------------
  *  @brief      Static member initialization.
  *
- *  Initializes The Running cycle, the static flag and mutex.
+ *  Initializes the running-cycle constant, the singleton-instance flag and the guarding mutex.
  */
 constexpr std::uint32_t kRunningCycle{5000U};
-bool DemoManager::instanceCreated_{false};
-std::mutex DemoManager::mutex_{};
+bool                    DemoManager::instanceCreated_{false};
+std::mutex              DemoManager::mutex_{};          // used only for singleton & wait-loop
 
 /** -------------------------------------------------------------------------------------------------------------------
  *  @brief      Retrieves the unique instance of DemoManager.
@@ -49,218 +52,153 @@ std::mutex DemoManager::mutex_{};
  *  @return     std::optional<std::reference_wrapper<DemoManager>> Optional containing the instance reference or
  *              an empty optional if the instance has already been created.
  */
-auto DemoManager::StartManager() noexcept -> std::optional<std::reference_wrapper<DemoManager>> {
+auto DemoManager::StartManager() noexcept -> std::optional<std::reference_wrapper<DemoManager>>
+{
     std::lock_guard<std::mutex> lock(mutex_);
-    if (instanceCreated_) {
+    if (instanceCreated_) {                      // somebody already grabbed it
         return std::nullopt;
     }
-    static DemoManager instance;
+    static DemoManager instance;                 // static-lifetime, no heap
     instanceCreated_ = true;
     return std::ref(instance);
 }
 
 /** -------------------------------------------------------------------------------------------------------------------
  *  @brief      Private constructor implementation.
- *
- *  Initializes the DemoManager instance. Any required initialization code can be placed here.
  */
 DemoManager::DemoManager() noexcept
-    : graceful_shutdown_handler_thread_{},
-      shutdown_notifier_{},
-      turn_off_requested_{false}
+  : graceful_shutdown_handler_thread_{},
+    shutdown_notifier_{},
+    turn_off_requested_{false}
 {
     InitializeDemoManager();
 }
 
-DemoManager::~DemoManager() noexcept {
-
-    std::cout << "[demo mngr][INFO] Demo Manager demolished."<< std::endl;
+DemoManager::~DemoManager() noexcept
+{
+    std::cout << "[demo mngr][INFO] Demo Manager demolished." << std::endl;
 }
 
 /** -------------------------------------------------------------------------------------------------------------------
  *  @brief      Private init method implementation.
- *
- *   the instance init sequence.
  */
-auto DemoManager::InitializeDemoManager() noexcept -> void {
-
-    /*Start the signal handler thread and check for errors in thread creation*/
+auto DemoManager::InitializeDemoManager() noexcept -> void
+{
+    /* Spawn the dedicated signal-handling thread */
     graceful_shutdown_handler_thread_ = std::thread(&DemoManager::GracefulShutdownHandler, this);
     if (!graceful_shutdown_handler_thread_.joinable()) {
-
         ara::core::Abort("[demo mngr][FATAL] Graceful shutdown handler thread creation failed.");
     }
 
-
-    std::cout << "[demo mngr][INFO] Demo Manager initialized successfuly."<< std::endl;
+    std::cout << "[demo mngr][INFO] Demo Manager initialized successfully." << std::endl;
 }
 
 /** -------------------------------------------------------------------------------------------------------------------
- *  @brief      Private init method implementation.
- *
- *   the instance init sequence.
+ *  @brief      Signal-handler thread: waits for SIGTERM/SIGINT and requests shutdown.
  */
-auto DemoManager::GracefulShutdownHandler() noexcept -> void {
-    
-    /*Set shutdown thread name for debugging*/
+auto DemoManager::GracefulShutdownHandler() noexcept -> void
+{
+    /* Set thread name for debugging */
     pthread_setname_np(pthread_self(), "demo_sig");
 
-    bool success{false};
-    
-    sigset_t singals{};
+    sigset_t signals{};
+    constexpr ara::core::Array<int, 2> kShutdownSigs{SIGTERM, SIGINT};
 
-    int def_sig{-1};
-
-    constexpr const ara::core::Array<int,2> kShutdownSigs{SIGTERM, SIGINT};
-
-    auto const add_sig_status = [&singals](int const& sig)  noexcept -> bool {
-
-        return (sigaddset(&singals, sig) == 0);
-    };
-
-    /*Empty the unitialized signal set*/
-    if(sigemptyset(&singals) == 0) {
-        
-        /*add the SIGTERM, and SIGINT to the singal set*/
-        if(std::all_of(kShutdownSigs.cbegin(), kShutdownSigs.cend(), add_sig_status)) {
-
-            /*Block these signals in this thread so they can be caught by sigwait*/
-            if (pthread_sigmask(SIG_BLOCK, &singals, nullptr) == 0) {
-
-                /*The thread is blocked and Wait for a signal to be received*/
-                if(sigwait(&singals, &def_sig) == 0) {
-                    
-                    std::lock_guard<std::mutex> lock(mutex_);
-
-                    switch(def_sig) {
-
-                        case kShutdownSigs[0]:
-
-                            std::cout << "[demo mngr][INFO] Demo Manager caught a SIGTERM." << std::endl;
-                            break;
-                        
-                        case kShutdownSigs[1]:
-                            std::cout << "[demo mngr][INFO] Demo Manager caught a SIGINT." << std::endl;
-                            break;
-
-                    }
-
-                    turn_off_requested_.store(true);
-                    shutdown_notifier_.notify_all();
-                    success = true;
-
-                }
-            }
-        }
+    if (sigemptyset(&signals) != 0 ||
+        std::any_of(kShutdownSigs.cbegin(), kShutdownSigs.cend(),
+                    [&signals](int s) { return sigaddset(&signals, s) != 0; }) ||
+        pthread_sigmask(SIG_BLOCK, &signals, nullptr) != 0)
+    {
+        ara::core::Abort("[demo mngr][FATAL] Initialise shutdown signal handling failed.");
     }
 
-    if(!success) {
-
-        ara::core::Abort("[demo mngr][FATAL] Initialize shutdown signal handling failed.");
+    int received{};
+    if (sigwait(&signals, &received) != 0) {
+        ara::core::Abort("[demo mngr][FATAL] sigwait() failed.");
     }
 
+    /* Log which signal we caught (no mutex required for console output) */
+    switch (received) {
+        case SIGTERM: std::cout << "[demo mngr][INFO] Demo Manager caught a SIGTERM." << std::endl; break;
+        case SIGINT:  std::cout << "[demo mngr][INFO] Demo Manager caught a SIGINT."  << std::endl; break;
+        default:      std::cout << "[demo mngr][WARN] Demo Manager caught an unknown signal." << std::endl; break;
+    }
 
-
-
+    /* --- Acquire/Release publication edge ---------------------------------- */
+    turn_off_requested_.store(true, std::memory_order_release);   // publish flag
+    shutdown_notifier_.notify_all();                              // wake manager loop
 }
 
 /** -------------------------------------------------------------------------------------------------------------------
  *  @brief      Runs the manager and returns an exit code.
- *
- *  Executes the primary functionality of the manager and returns a success exit code.
- *
- *  @return     std::uint8_t Exit code indicating success.
  */
-auto DemoManager::RunManager() noexcept -> std::uint8_t {
-    
+auto DemoManager::RunManager() noexcept -> std::uint8_t
+{
     std::uint8_t exit_code{EXIT_SUCCESS};
+    bool         thread_running{true};
 
-    bool thread_running{true};
-
-    /* Retrieve the native pthread handle */
-    pthread_t native_handle = pthread_self();
-
-    /* Define scheduling parameters */
+    pthread_t   native_handle = pthread_self();
     sched_param param{};
+    int         current_policy{-1};
 
-    int current_policy{-1};
-
-    /* Use unique_lock for compatibility with condition_variable */
-    std::unique_lock<std::mutex> lock(mutex_);
-
-    /* Get current scheduling parameters to preserve existing priority */ 
+    /* Preserve current scheduling parameters */
     if (pthread_getschedparam(native_handle, &current_policy, &param) != 0) {
-
         ara::core::Abort("[demo mngr][FATAL] Failed to get current scheduling parameters: ",
-                          std::strerror(errno));
+                         std::strerror(errno));
     }
 
-    std::cout << "[demo mngr][INFO] Manager Is on Running State" << std::endl;
+    std::cout << "[demo mngr][INFO] Manager is in Running state." << std::endl;
+
+    /* Unique_lock needed only for the condition-variable */
+    std::unique_lock<std::mutex> lock(mutex_);
 
     do {
         auto start_time = std::chrono::steady_clock::now();
 
-            std::cout << "[demo mngr][INFO] Current Scheduling Policy: ";
-            switch (current_policy) {
-                case SCHED_FIFO:
-                    std::cout << "SCHED_FIFO";
-                    break;
-                case SCHED_RR:
-                    std::cout << "SCHED_RR";
-                    break;
-                case SCHED_OTHER:
-                    std::cout << "SCHED_OTHER";
-                    break;
-                default:
-                    std::cout << "UNKNOWN";
-            }
-            std::cout << ", Priority: " << param.sched_priority << std::endl;
+        /* Periodic debug print */
+        std::cout << "[demo mngr][INFO] Current scheduling policy: ";
+        switch (current_policy) {
+            case SCHED_FIFO:  std::cout << "SCHED_FIFO";  break;
+            case SCHED_RR:    std::cout << "SCHED_RR";    break;
+            case SCHED_OTHER: std::cout << "SCHED_OTHER"; break;
+            default:          std::cout << "UNKNOWN";
+        }
+        std::cout << ", priority: " << param.sched_priority << std::endl;
 
-        /* Calculate the time taken and adjust the sleep duration accordingly */
+        /* Compute remaining time in the cycle */
         auto elapsed_time   = std::chrono::steady_clock::now() - start_time;
         auto remaining_time = std::chrono::milliseconds(kRunningCycle) - elapsed_time;
 
         if (remaining_time > std::chrono::milliseconds(0)) {
-
-            thread_running = !shutdown_notifier_.wait_for(lock, remaining_time, [this]() { 
-                return turn_off_requested_.load(); 
-            });
-
+            /* Wait until next tick *or* until the shutdown flag is published */
+            thread_running = !shutdown_notifier_.wait_for(
+                lock,
+                remaining_time,
+                [this] {
+                    return turn_off_requested_.load(std::memory_order_acquire);   // acquire edge
+                });
         } else {
+            std::cout << "[demo mngr][WARN] Manager over-ran the configured "
+                      << kRunningCycle << " ms cycle (took "
+                      << std::chrono::duration_cast<std::chrono::milliseconds>(elapsed_time).count()
+                      << " ms)." << std::endl;
 
-            std::cout << "[demo mngr][WARN] Manager took more than the configured time: "
-                            << kRunningCycle
-                            << " ms"
-                            << " and the execution,"
-                            << " time taken is: "
-                            << std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed_time).count())
-                            << " ms.";
-
-            thread_running = !turn_off_requested_.load();
-
+            thread_running = !turn_off_requested_.load(std::memory_order_acquire);
         }
-
-        
     } while (thread_running);
 
     TerminateDemoManager();
-    
-    return exit_code; // 0 typically indicates success
+    return exit_code;   // EXIT_SUCCESS
 }
 
-
 /** -------------------------------------------------------------------------------------------------------------------
- *  @brief      Private end of class method implementation.
- *
- *   the instance demolishing sequence.
+ *  @brief      Private tear-down sequence.
  */
-auto DemoManager::TerminateDemoManager() noexcept -> void {
-
+auto DemoManager::TerminateDemoManager() noexcept -> void
+{
     if (graceful_shutdown_handler_thread_.joinable()) {
-
         graceful_shutdown_handler_thread_.join();
     }
-
 }
 
 } // namespace manager

--- a/components/open-aa-std-adaptive-autosar-libs/CMakeLists.txt
+++ b/components/open-aa-std-adaptive-autosar-libs/CMakeLists.txt
@@ -58,6 +58,23 @@ target_link_libraries(ara_core_array INTERFACE
 )
 
 # ----------------------------------------------------------------------
+# 3) ARA::CORE::Byte
+# ----------------------------------------------------------------------
+add_library(ara_core_byte INTERFACE)
+add_library(ara::core::byte ALIAS ara_core_byte)
+
+# Provide include directories for ara::core::byte
+target_include_directories(ara_core_byte INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>  # Path to byte headers during build
+    $<INSTALL_INTERFACE:include>                            # Path to byte headers after installation
+)
+
+# link INTERFACE libraries
+target_link_libraries(ara_core_byte INTERFACE
+    ara::core::violation
+)
+
+# ----------------------------------------------------------------------
 # 3) Installation of Headers
 # ----------------------------------------------------------------------
 # Install the ara/core headers, including array.h and internal headers
@@ -71,7 +88,7 @@ install(DIRECTORY
 # 4) Export & Package: ara_core_targets
 # ----------------------------------------------------------------------
 # Create a single export set for all ara::core targets to avoid duplication
-install(TARGETS ara_core_abort ara_core_violation ara_core_array
+install(TARGETS ara_core_abort ara_core_violation ara_core_array ara_core_byte
     EXPORT ara_core_targets  # Single export set for both targets
     ARCHIVE DESTINATION lib/core                    # Installation path for static libraries
     LIBRARY DESTINATION lib                         # Installation path for shared libraries (if applicable)

--- a/components/open-aa-std-adaptive-autosar-libs/include/ara/core/array.h
+++ b/components/open-aa-std-adaptive-autosar-libs/include/ara/core/array.h
@@ -51,31 +51,6 @@
 
 
 /**********************************************************************************************************************
- *  SECTION: Forward Declaration
- *********************************************************************************************************************/
-namespace ara::core {
-/*!
- * \brief  Forward declaration of the get function template.
- */
-template <std::size_t I, typename T, std::size_t N>
-constexpr auto get(ara::core::Array<T,N>&) noexcept -> T&;
-
-/*!
- * \brief  Forward declaration of the get function template.
- */
-template <std::size_t I, typename T, std::size_t N>
-constexpr auto get(const ara::core::Array<T,N>&) noexcept -> const T&;
-
-/*!
- * \brief  Forward declaration of the get function template.
- */
-template <std::size_t I, typename T, std::size_t N>
-constexpr auto get(ara::core::Array<T,N>&&) noexcept -> T&&;
-
-} // namespace ara::core
-
-
-/**********************************************************************************************************************
  *  TUPLE: INTERFACE SPECIALISATIONS
  *  ---------------------------------------------------------------------------------------------------------------
  *  std::tuple_size          [SWS_CORE_01280]
@@ -152,7 +127,67 @@ namespace std {
         using type = T;                         // every element is T
     };
 } // namespace std
- 
+
+
+/**********************************************************************************************************************
+ *  TUPLE-LIKE UTILITIES
+ *  ---------------------------------------------------------------------------------------------------------------
+ *  ara::core::apply      – constexpr replacement for std::apply that works with ADL
+ *  ara::core::tuple_cat  – concatenates any number of tuple-protocol objects
+ *********************************************************************************************************************/
+namespace ara {
+namespace core {
+
+/**********************************************************************************************************************
+ *  ara::core::apply
+ *********************************************************************************************************************/
+/*! 
+ * \brief  Applies a callable to the elements of a tuple-like object.
+ *
+ * \details
+ * - This function is a constexpr replacement for std::apply that works with ADL.
+ * - It forwards the callable and the tuple-like object, expanding the tuple-like object's elements as arguments to the callable.
+ *
+ * \tparam F     The type of the callable (function, lambda, etc.).
+ * \tparam Tuple The type of the tuple-like object.
+ * \param f   The callable to apply.
+ * \param tup The tuple-like object containing the elements to pass to the callable.
+ * \return    The result of calling f with the unpacked elements of tup.
+ */
+template<typename F, typename Tuple,
+         typename = std::enable_if_t<
+             detail::is_tuple_like_v<std::remove_reference_t<Tuple>>>>
+constexpr decltype(auto) apply(F&& f, Tuple&& tup)
+{
+    constexpr std::size_t N =
+        std::tuple_size_v<std::remove_cv_t<std::remove_reference_t<Tuple>>>;
+    return detail::apply_impl(std::forward<F>(f),
+                              std::forward<Tuple>(tup),
+                              std::make_index_sequence<N>{});
+}
+
+/*!
+ * \brief  Concatenates any number of tuple-like objects into a single std::tuple.
+ *
+ * \details
+ * - This function concatenates any number of tuple-like objects into a single std::tuple.
+ * - It uses detail::to_std_tuple to convert each tuple-like object to a std::tuple before concatenation.
+ *
+ * \tparam Tuples The types of the tuple-like objects to concatenate.
+ * \param tpls   The tuple-like objects to concatenate.
+ * \return       A std::tuple containing all elements from the input tuple-like objects.
+ */
+template<typename... Tuples,
+         typename = std::enable_if_t<
+             (detail::is_tuple_like_v<std::remove_reference_t<Tuples>> && ... )>>
+constexpr auto tuple_cat(Tuples&&... tpls)
+{
+    return std::tuple_cat( detail::to_std_tuple(std::forward<Tuples>(tpls))... );
+}
+
+} // namespace core
+} // namespace ara
+
 
 /**********************************************************************************************************************
  *  NAMESPACE: ara::core

--- a/components/open-aa-std-adaptive-autosar-libs/include/ara/core/array.h
+++ b/components/open-aa-std-adaptive-autosar-libs/include/ara/core/array.h
@@ -45,6 +45,7 @@
 #include <cstring>                                  // For std::memcpy, std::memset
 #include <iterator>                                 // For std::reverse_iterator
 
+#include "ara/core/byte.h"                          // For ara::core::Byte type
 #include "ara/core/internal/utility.h"              // For utility functions and traits
 #include "ara/core/internal/location_utils.h"       // For capturing file/line details
 #include "ara/core/internal/violation_handler.h"    // To Trigger the violation
@@ -225,7 +226,7 @@ template <typename T, std::size_t N>
 class Array final : private detail::ArrayStorage<T, N>
 {
 public:
-#ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     // In Conditional Safe Mode, allow potentially-throwing types
 #else
     /*!
@@ -287,7 +288,7 @@ public:
                   (!detail::is_single_same_array_v<Args...>)
               >>
     constexpr Array(Args&&... args) 
-#ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
         noexcept(std::conjunction_v<std::is_nothrow_constructible<T, Args&&>...>)
 #else
         noexcept
@@ -295,7 +296,7 @@ public:
         : detail::ArrayStorage<T, N>(std::forward<Args>(args)...)
     {
         // Base class handles data_ initialization.
-#ifndef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifndef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
         static_assert(std::conjunction_v<std::is_nothrow_constructible<T, Args&&>...>,
             "\n[ERROR] in ara::core::Array: The type T and args must be noexcept.\n");
 #endif
@@ -730,7 +731,7 @@ public:
      */
     template <typename U = T, size_type M = N>
     constexpr auto fill(const T& val)
-#ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     noexcept(std::is_nothrow_copy_assignable_v<T>)
 #else
     noexcept
@@ -739,7 +740,7 @@ public:
                         std::is_trivially_constructible_v<U> && (M > 0), void>
     {
 
-#ifndef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifndef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
         // Ensure T's fill is noexcept if exceptions are disabled
         static_assert(std::is_nothrow_copy_assignable_v<T>,
             "\n[ERROR] ara::core::Array: The type T's fill operation must be noexcept when exceptions are disabled.\n");
@@ -781,7 +782,7 @@ public:
      */
     template <typename U = T, size_type M = N>
     constexpr auto fill(const T& val)
-#ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     noexcept(std::is_nothrow_copy_assignable_v<T>)
 #else
     noexcept
@@ -790,7 +791,7 @@ public:
                         !std::is_trivially_constructible_v<U> && (M > 0), void>
     {
 
-#ifndef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifndef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
         // Ensure T's fill is noexcept if exceptions are disabled
         static_assert(std::is_nothrow_copy_assignable_v<T>,
             "\n[ERROR] ara::core::Array: The type T's fill operation must be noexcept when exceptions are disabled.\n");
@@ -832,7 +833,7 @@ public:
      */
     template <typename U = T, size_type M = N>
     constexpr auto fill(const T& val)
-#ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     noexcept(std::is_nothrow_copy_assignable_v<T>)
 #else
     noexcept
@@ -840,7 +841,7 @@ public:
     -> std::enable_if_t<!std::is_trivially_copyable_v<U> || (M == 0), void>
     {
 
-#ifndef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifndef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
         // Ensure T's fill is noexcept if exceptions are disabled
         static_assert(std::is_nothrow_copy_assignable_v<T>,
             "\n[ERROR] ara::core::Array: The type T's fill operation must be noexcept when exceptions are disabled.\n");
@@ -869,14 +870,14 @@ public:
      */
     template <typename U = T, size_type M = N>
     constexpr auto swap(Array& other) 
-#ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
         noexcept(noexcept(std::swap(std::declval<T&>(), std::declval<T&>())))
 #else
         noexcept
 #endif
     -> std::enable_if_t<std::is_trivially_copyable_v<U> && (M > 0), void>
     {   
-#ifndef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifndef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
         // Ensure T's swap is noexcept if exceptions are disabled
         static_assert(noexcept(std::swap(std::declval<T&>(), std::declval<T&>())),
             "\n[ERROR] ara::core::Array: The type T's swap operation must be noexcept when exceptions are disabled.\n");
@@ -910,14 +911,14 @@ public:
      */
     template <typename U = T, size_type M = N>
     constexpr auto swap(Array& other) 
-#ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
         noexcept(noexcept(std::swap(std::declval<T&>(), std::declval<T&>())))
 #else
         noexcept
 #endif
     -> std::enable_if_t<!std::is_trivially_copyable_v<U> || (M == 0), void>
     {   
-#ifndef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifndef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
         // Ensure T's swap is noexcept if exceptions are disabled
         static_assert(noexcept(std::swap(std::declval<T&>(), std::declval<T&>())),
             "\n[ERROR] ara::core::Array: The type T's swap operation must be noexcept when exceptions are disabled.\n");
@@ -1048,14 +1049,14 @@ constexpr auto get(const Array<T, N>& arr) noexcept -> const T&
  */
 template <typename T, std::size_t N>
 constexpr auto operator==(const Array<T, N>& lhs, const Array<T, N>& rhs)
-#ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     noexcept(noexcept(std::declval<T&>() == std::declval<T&>()))
 #else
     noexcept
 #endif
 -> std::enable_if_t<std::is_trivially_copyable_v<T> && std::is_standard_layout_v<T>, bool>
 {
-#ifndef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifndef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     static_assert(noexcept(std::declval<T&>() == std::declval<T&>()),
         "\n[ERROR] in ara::core::Array: The type T's operator== must be marked 'noexcept' when exceptions are disabled.\n");
 #endif
@@ -1086,14 +1087,14 @@ constexpr auto operator==(const Array<T, N>& lhs, const Array<T, N>& rhs)
  */
 template <typename T, std::size_t N>
 constexpr auto operator==(const Array<T, N>& lhs, const Array<T, N>& rhs)
-#ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     noexcept(noexcept(std::declval<T&>() == std::declval<T&>()))
 #else
     noexcept
 #endif
 -> std::enable_if_t<!std::is_trivially_copyable_v<T> || !std::is_standard_layout_v<T>, bool>
 {
-#ifndef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifndef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     static_assert(noexcept(std::declval<T&>() == std::declval<T&>()),
         "\n[ERROR] in ara::core::Array: The type T's operator== must be marked 'noexcept' when exceptions are disabled.\n");
 #endif
@@ -1120,14 +1121,14 @@ constexpr auto operator==(const Array<T, N>& lhs, const Array<T, N>& rhs)
  */
 template <typename T, std::size_t N>
 constexpr auto operator!=(const Array<T, N>& lhs, const Array<T, N>& rhs)
-#ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     noexcept(noexcept(!(lhs == rhs)))
 #else
     noexcept
 #endif
 -> bool
 {
-#ifndef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifndef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     static_assert(noexcept(!(lhs == rhs)),
         "\n[ERROR] in ara::core::Array: The operator!= must be marked 'noexcept' when exceptions are disabled.\n");
 #endif
@@ -1148,7 +1149,7 @@ constexpr auto operator!=(const Array<T, N>& lhs, const Array<T, N>& rhs)
  */
 template <typename T, std::size_t N>
 constexpr auto operator<(const Array<T, N>& lhs, const Array<T, N>& rhs)
-#ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     noexcept(noexcept(std::declval<T&>() < std::declval<T&>()))
 #else
     noexcept
@@ -1156,7 +1157,7 @@ constexpr auto operator<(const Array<T, N>& lhs, const Array<T, N>& rhs)
 -> std::enable_if_t<std::is_trivially_copyable_v<T> && std::is_standard_layout_v<T> &&
                     (sizeof(T) == 1), bool>
 {
-#ifndef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifndef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     static_assert(noexcept(std::declval<T&>() < std::declval<T&>()),
         "\n[ERROR] in ara::core::Array: The type T's operator< must be marked 'noexcept' when exceptions are disabled.\n");
 #endif
@@ -1183,7 +1184,7 @@ constexpr auto operator<(const Array<T, N>& lhs, const Array<T, N>& rhs)
  */
 template <typename T, std::size_t N>
 constexpr auto operator<(const Array<T, N>& lhs, const Array<T, N>& rhs)
-#ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     noexcept(noexcept(std::declval<T&>() < std::declval<T&>()))
 #else
     noexcept
@@ -1191,7 +1192,7 @@ constexpr auto operator<(const Array<T, N>& lhs, const Array<T, N>& rhs)
 -> std::enable_if_t<!std::is_trivially_copyable_v<T> || !std::is_standard_layout_v<T> ||
                     (sizeof(T) != 1), bool>
 {
-#ifndef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifndef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     static_assert(noexcept(std::declval<T&>() < std::declval<T&>()),
         "\n[ERROR] in ara::core::Array: The type T's operator< must be marked 'noexcept' when exceptions are disabled.\n");
 #endif
@@ -1213,14 +1214,14 @@ constexpr auto operator<(const Array<T, N>& lhs, const Array<T, N>& rhs)
  */
 template <typename T, std::size_t N>
 constexpr auto operator<=(const Array<T, N>& lhs, const Array<T, N>& rhs)
-#ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     noexcept(noexcept(!(rhs < lhs)))
 #else
     noexcept
 #endif
 -> bool
 {
-#ifndef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifndef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     static_assert(noexcept(!(rhs < lhs)),
         "\n[ERROR] in ara::core::Array: The operator<= must be marked 'noexcept' when exceptions are disabled.\n");
 #endif
@@ -1241,14 +1242,14 @@ constexpr auto operator<=(const Array<T, N>& lhs, const Array<T, N>& rhs)
  */
 template <typename T, std::size_t N>
 constexpr auto operator>(const Array<T, N>& lhs, const Array<T, N>& rhs)
-#ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     noexcept(noexcept(rhs < lhs))
 #else
     noexcept
 #endif
 -> bool
 {
-#ifndef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifndef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     static_assert(noexcept(rhs < lhs),
         "\n[ERROR] in ara::core::Array: The operator> must be marked 'noexcept' when exceptions are disabled.\n");
 #endif
@@ -1269,14 +1270,14 @@ constexpr auto operator>(const Array<T, N>& lhs, const Array<T, N>& rhs)
  */
 template <typename T, std::size_t N>
 constexpr auto operator>=(const Array<T, N>& lhs, const Array<T, N>& rhs)
-#ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     noexcept(noexcept(!(lhs < rhs)))
 #else
     noexcept
 #endif
 -> bool
 {
-#ifndef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifndef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     static_assert(noexcept(!(lhs < rhs)),
         "\n[ERROR] in ara::core::Array: The operator>= must be marked 'noexcept' when exceptions are disabled.\n");
 #endif
@@ -1302,20 +1303,61 @@ constexpr auto operator>=(const Array<T, N>& lhs, const Array<T, N>& rhs)
  */
 template <typename T, std::size_t N>
 constexpr auto swap(Array<T, N>& lhs, Array<T, N>& rhs)
-#ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     noexcept(noexcept(lhs.swap(rhs)))
 #else
     noexcept
 #endif
 -> void
 {
-#ifndef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifndef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
     // Ensure T's swap is noexcept if exceptions are disabled
     static_assert(noexcept(lhs.swap(rhs)),
         "\n[ERROR] ara::core::Array: The type T's swap operation must be noexcept when exceptions are disabled.\n");
 #endif
 
     lhs.swap(rhs);
+}
+
+/********************************************************************************************
+ *  to_array - Modern C++ utility [Enhancement beyond AUTOSAR spec]
+ ********************************************************************************************/
+/*!
+ * \brief  Creates an ara::core::Array from a built-in array (lvalue).
+ *
+ * \tparam T  The element type.
+ * \tparam N  The number of elements.
+ * \param  a  The built-in array to convert.
+ * \return    An ara::core::Array containing copies of the elements.
+ *
+ * \details This is similar to std::to_array from C++20, adapted for ara::core::Array.
+ *          Enables: auto arr = ara::core::to_array({1, 2, 3, 4});
+ *
+ * \note   This is an enhancement beyond base AUTOSAR requirements for modern C++ compatibility.
+ */
+template <typename T, std::size_t N>
+constexpr auto to_array(T (&a)[N]) noexcept(std::is_nothrow_copy_constructible_v<T>) -> Array<T, N>
+{
+    return detail::to_array_impl(a, std::make_index_sequence<N>{});
+}
+
+/*!
+ * \brief  Creates an ara::core::Array from a built-in array (rvalue).
+ *
+ * \tparam T  The element type.
+ * \tparam N  The number of elements.
+ * \param  a  The built-in array to move from.
+ * \return    An ara::core::Array containing moved elements.
+ *
+ * \details This is similar to std::to_array from C++20, adapted for ara::core::Array.
+ *          Enables move semantics for array creation.
+ *
+ * \note   This is an enhancement beyond base AUTOSAR requirements for modern C++ compatibility.
+ */
+template <typename T, std::size_t N>
+constexpr auto to_array(T (&&a)[N]) noexcept(std::is_nothrow_move_constructible_v<T>) -> Array<T, N>
+{
+    return detail::to_array_impl(std::move(a), std::make_index_sequence<N>{});
 }
 
 /********************************************************************************************

--- a/components/open-aa-std-adaptive-autosar-libs/include/ara/core/byte.h
+++ b/components/open-aa-std-adaptive-autosar-libs/include/ara/core/byte.h
@@ -1,0 +1,1325 @@
+/**********************************************************************************************************************
+ *  PROJECT
+ *  -------------------------------------------------------------------------------------------------------------------
+ *  \verbatim
+ *  OpenAA: Open Source Adaptive AUTOSAR Project (CXX_STANDARD 17)
+ *  Author: Sherif Mohamed
+ *  \endverbatim
+ *  -------------------------------------------------------------------------------------------------------------------
+ *  FILE DESCRIPTION
+ *  -------------------------------------------------------------------------------------------------------------------
+ *  \file       ara/core/byte.h
+ *  \brief      Definition and implementation of the ara::core::Byte type.
+ *
+ *  \details    This file defines and implements the ara::core::Byte type, a strong type-safe byte representation
+ *              designed for the OpenAA project. It provides functionality similar to std::byte with additional
+ *              enhancements and safety features to meet Adaptive AUTOSAR requirements (e.g., [SWS_CORE_10104],
+ *              [SWS_CORE_10105], [SWS_CORE_10106], [SWS_CORE_10107], etc.), including violation handling and
+ *              enhanced operations beyond the base specification.
+ *
+ *  \note       Based on the Adaptive AUTOSAR SWS (e.g., R24-11) requirements for the "Byte" type, especially:
+ *              - [SWS_CORE_10102] (Value range requirements)
+ *              - [SWS_CORE_10104] (Default construction)
+ *              - [SWS_CORE_10105] (Trivial destructor)
+ *              - [SWS_CORE_10106] (No implicit conversion from other types)
+ *              - [SWS_CORE_10107] (No implicit conversion to other types)
+ *              - [SWS_CORE_10108] (Additional conversion restrictions)
+ *              - Enhanced with C++26-like features while maintaining C++17 compatibility
+ *********************************************************************************************************************/
+
+#ifndef OPEN_AA_ADAPTIVE_AUTOSAR_LIBS_INCLUDE_ARA_CORE_BYTE_H_
+#define OPEN_AA_ADAPTIVE_AUTOSAR_LIBS_INCLUDE_ARA_CORE_BYTE_H_
+
+/**********************************************************************************************************************
+ *  CONFIGURATION MACROS
+ *********************************************************************************************************************/
+/*!
+ * \brief  Configuration macros for optional features
+ *
+ * ENABLE_PLATFORM_CONDITIONAL_EXCEPTION - Enable conditional noexcept based on operations
+ * ARA_CORE_BYTE_ENABLE_IOSTREAM - Enable stream operators for debugging
+ */
+
+/**********************************************************************************************************************
+ *  INCLUDES: files that required by the byte type
+ *********************************************************************************************************************/
+/*!
+ * \brief  Includes necessary standard headers for byte operations, plus any additional
+ *         headers for violation handling or type traits (per AUTOSAR guidelines).
+ *
+ * [SWS_CORE_10102]: cstdint for std::uint8_t underlying type
+ * [SWS_CORE_10104]: type_traits for trivial construction checks
+ * [SWS_CORE_10105]: type_traits for trivial destructor verification
+ * [SWS_CORE_10106], [SWS_CORE_10107]: we prevent implicit conversions
+ */
+#include <cstdint>                                  // For std::uint8_t
+#include <cstddef>                                  // For std::size_t
+#include <type_traits>                              // For type trait checks
+#include <iosfwd>                                   // For stream forward declarations
+#include <limits>                                   // For numeric_limits
+#include <bitset>                                   // For bitset in test code
+
+#include "ara/core/internal/utility.h"              // For utility functions and traits
+#include "ara/core/internal/location_utils.h"       // For capturing file/line details
+#include "ara/core/internal/violation_handler.h"    // To trigger violations
+#include "ara/core/abort.h"                         // For direct abort on non-specified violations
+
+/**********************************************************************************************************************
+ *  NAMESPACE: ara::core
+ *********************************************************************************************************************/
+/*!
+ * \brief  The ara::core namespace, within which our AUTOSAR Adaptive Platform
+ *         data types and utilities reside.
+ */
+namespace ara {
+namespace core {
+
+/**********************************************************************************************************************
+ *  CLASS: ara::core::Byte
+ *********************************************************************************************************************/
+/*!
+ * \brief  A type-safe byte representation for the Adaptive AUTOSAR platform.
+ *
+ * \details
+ * - [SWS_CORE_10102]: Represents values in the range [0, 255]
+ * - [SWS_CORE_10104]: Default constructible with indeterminate value at no runtime cost
+ * - [SWS_CORE_10105]: Trivial destructor
+ * - [SWS_CORE_10106]: No implicit conversions from other types
+ * - [SWS_CORE_10107]: No implicit conversions to other types (including bool)
+ * - Enhanced beyond AUTOSAR spec with modern C++26-like features
+ * - Provides comprehensive bitwise and comparison operators
+ * - Strict type safety with violation handling for invalid operations
+ *
+ * \note Unlike std::byte, this implementation provides more ergonomic construction
+ *       and enhanced safety features while maintaining zero-overhead abstraction.
+ * 
+ * \note Thread Safety: All const member functions are thread-safe. Non-const member
+ *       functions require external synchronization when accessed from multiple threads.
+ */
+class Byte final
+{
+public:
+    // -----------------------------------------------------------------------------------
+    // TYPE ALIASES (public)
+    // -----------------------------------------------------------------------------------
+    using underlying_type = std::uint8_t;  /*!< Expose underlying type for explicit access */
+
+    // -----------------------------------------------------------------------------------
+    // CONSTRUCTORS AND DESTRUCTOR
+    // -----------------------------------------------------------------------------------
+    
+    /*!
+     * \brief Default constructor - creates byte with indeterminate value.
+     *
+     * \details
+     * - [SWS_CORE_10104]: Default construction with no initializer
+     * - No runtime cost incurred
+     * - Value is indeterminate (not zero-initialized)
+     *
+     * \note This follows AUTOSAR spec exactly - use Byte{} or Byte{0} for zero initialization
+     * \note Cannot be constexpr in C++17 due to uninitialized member
+     */
+    Byte() noexcept = default;
+
+    /*!
+     * \brief Construct from integral value with bounds checking.
+     *
+     * \tparam IntegralType Type of the integral value (must be integral)
+     * \param val The value to initialize the byte with
+     *
+     * \details
+     * - Explicit constructor prevents implicit conversions [SWS_CORE_10106]
+     * - Compile-time bounds checking for constant expressions
+     * - Runtime violation for out-of-range values in non-constant contexts
+     * - Enhanced beyond AUTOSAR: accepts any integral type with proper checking
+     *
+     * \note Values outside [0, 255] trigger violation handler
+     */
+    template <typename IntegralType,
+              typename = std::enable_if_t<std::is_integral_v<IntegralType>>>
+    constexpr explicit Byte(IntegralType val) 
+#ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
+        noexcept(!std::numeric_limits<IntegralType>::is_signed || 
+                 (std::numeric_limits<IntegralType>::max() <= 255))
+#else
+        noexcept
+#endif
+        : value_(static_cast<underlying_type>(val))
+    {
+#ifndef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
+        // In strict no-exception mode, ensure construction is truly noexcept
+        static_assert(std::is_nothrow_constructible_v<underlying_type, IntegralType>,
+            "\n[ERROR] in ara::core::Byte: Construction must be noexcept when exceptions are disabled.\n");
+#endif
+        
+        // C++17 compatible bounds checking
+        if constexpr (std::is_signed_v<IntegralType>) {
+            if (!detail::is_constant_evaluated()) {
+                if (val < 0 || val > 255) {
+                    TriggerByteRangeViolation(ARA_CORE_INTERNAL_FILELINE, val);
+                }
+            }
+        } else {
+            if (!detail::is_constant_evaluated()) {
+                if (val > 255) {
+                    TriggerByteRangeViolation(ARA_CORE_INTERNAL_FILELINE, val);
+                }
+            }
+        }
+    }
+
+    /*!
+     * \brief Rejecting constructor for non-integral types.
+     *
+     * \tparam T Type that is not integral
+     * \param Type parameter (unused)
+     *
+     * \details
+     * - Catches attempts to construct Byte from non-integral types
+     * - Provides clear compile-time error message
+     * - Enforces [SWS_CORE_10106] - no implicit conversions
+     */
+    template <typename T,
+              typename = std::enable_if_t<!std::is_integral_v<T>>,
+              int = 0>
+    constexpr explicit Byte([[maybe_unused]] T t) noexcept
+    {
+        static_assert(std::is_integral_v<T>,
+            "\n[ERROR] Cannot construct ara::core::Byte from non-integral type!\n"
+            "        Byte can only be constructed from integral types.\n"
+            "        Use explicit casting if you need to convert from other types.\n");
+    }
+
+    /*!
+     * \brief Destructor - trivial as required by [SWS_CORE_10105]
+     * \note Cannot be constexpr in C++17
+     */
+    ~Byte() noexcept = default;
+
+    /*!
+     * \brief Copy constructor - defaulted for trivial copyability
+     */
+    constexpr Byte(const Byte&) noexcept = default;
+
+    /*!
+     * \brief Move constructor - defaulted for trivial movability
+     */
+    constexpr Byte(Byte&&) noexcept = default;
+
+    /*!
+     * \brief Copy assignment - defaulted for trivial assignability
+     */
+    constexpr auto operator=(const Byte&) noexcept -> Byte& = default;
+
+    /*!
+     * \brief Move assignment - defaulted for trivial assignability
+     */
+    constexpr auto operator=(Byte&&) noexcept -> Byte& = default;
+
+    // -----------------------------------------------------------------------------------
+    // EXPLICIT CONVERSIONS [SWS_CORE_10107]
+    // -----------------------------------------------------------------------------------
+    
+    /*!
+     * \brief Explicit conversion to integral types.
+     *
+     * \tparam IntegralType Target integral type
+     * \return The byte value as the requested integral type
+     *
+     * \details
+     * - [SWS_CORE_10107]: No implicit conversions allowed
+     * - Must use static_cast or explicit conversion
+     * - Safe for any integral type (proper value preservation)
+     *
+     * \note Enhanced: Works with any integral type, not just uint8_t
+     */
+    template <typename IntegralType,
+              typename = std::enable_if_t<std::is_integral_v<IntegralType>>>
+    constexpr explicit operator IntegralType() const noexcept
+    {
+        return static_cast<IntegralType>(value_);
+    }
+
+    /*!
+     * \brief Deleted bool conversion operator.
+     *
+     * \details
+     * - [SWS_CORE_10107]: Explicitly prevents implicit conversion to bool
+     * - Provides clear compile-time error if attempted
+     */
+    explicit operator bool() const = delete;
+
+    /*!
+     * \brief Get underlying value explicitly.
+     *
+     * \return The underlying uint8_t value
+     *
+     * \details
+     * - Provides named access to underlying value
+     * - Alternative to static_cast for clarity
+     * - Enhanced beyond AUTOSAR for better API ergonomics
+     */
+    [[nodiscard]] constexpr auto to_integer() const noexcept -> underlying_type
+    {
+        return value_;
+    }
+
+    /*!
+     * \brief Get underlying value via template function.
+     *
+     * \tparam IntegralType Target integral type
+     * \return The byte value as the requested type
+     *
+     * \details
+     * - Template version of to_integer for any integral type
+     * - Enhanced API for modern C++ usage patterns
+     */
+    template <typename IntegralType,
+              typename = std::enable_if_t<std::is_integral_v<IntegralType>>>
+    [[nodiscard]] constexpr auto to_integer() const noexcept -> IntegralType
+    {
+        return static_cast<IntegralType>(value_);
+    }
+
+    // -----------------------------------------------------------------------------------
+    // BITWISE OPERATORS (COMPOUND ASSIGNMENT)
+    // -----------------------------------------------------------------------------------
+    
+    /*!
+     * \brief Bitwise AND assignment operator.
+     *
+     * \param other The byte to AND with
+     * \return Reference to this byte after operation
+     *
+     * \details
+     * - Modifies this byte in-place
+     * - Part of comprehensive bitwise operator set
+     * - Enhanced beyond base AUTOSAR requirements
+     */
+    constexpr auto operator&=(Byte other) noexcept -> Byte&
+    {
+        value_ = static_cast<underlying_type>(value_ & other.value_);
+        return *this;
+    }
+
+    /*!
+     * \brief Bitwise OR assignment operator.
+     *
+     * \param other The byte to OR with
+     * \return Reference to this byte after operation
+     */
+    constexpr auto operator|=(Byte other) noexcept -> Byte&
+    {
+        value_ = static_cast<underlying_type>(value_ | other.value_);
+        return *this;
+    }
+
+    /*!
+     * \brief Bitwise XOR assignment operator.
+     *
+     * \param other The byte to XOR with
+     * \return Reference to this byte after operation
+     */
+    constexpr auto operator^=(Byte other) noexcept -> Byte&
+    {
+        value_ = static_cast<underlying_type>(value_ ^ other.value_);
+        return *this;
+    }
+
+    /*!
+     * \brief Left shift assignment operator.
+     *
+     * \param shift Number of positions to shift
+     * \return Reference to this byte after operation
+     *
+     * \details
+     * - Shift amount is masked to valid range [0, 7]
+     * - Prevents undefined behavior from over-shifting
+     * - Enhanced safety beyond standard requirements
+     */
+    template <typename IntegralType,
+              typename = std::enable_if_t<std::is_integral_v<IntegralType>>>
+    constexpr auto operator<<=(IntegralType shift) noexcept -> Byte&
+    {
+        if (!detail::is_constant_evaluated()) {
+            if (shift < 0 || shift >= 8) {
+                ara::core::Abort("Byte shift amount out of range [0, 7]");
+            }
+        }
+        value_ = static_cast<underlying_type>(
+            static_cast<underlying_type>(value_ << (static_cast<unsigned>(shift) & 0x7u))
+        );
+        return *this;
+    }
+
+    /*!
+     * \brief Rejecting left shift assignment for non-integral types.
+     *
+     * \tparam T Non-integral type
+     * \param shift Invalid shift type (unused)
+     *
+     * \details
+     * - Provides clear compile-time error message
+     * - Prevents accidental misuse of shift assignment
+     */
+    template <typename T,
+              typename = std::enable_if_t<!std::is_integral_v<T>>,
+              int = 0>
+    constexpr auto operator<<=([[maybe_unused]] T shift) noexcept -> Byte&
+    {
+        static_assert(std::is_integral_v<T>,
+            "\n[ERROR] Cannot shift-assign ara::core::Byte with non-integral type!\n"
+            "        Shift amount must be an integral type.\n");
+        return *this;  // Never reached
+    }
+
+    /*!
+     * \brief Right shift assignment operator.
+     *
+     * \param shift Number of positions to shift
+     * \return Reference to this byte after operation
+     *
+     * \details
+     * - Shift amount is masked to valid range [0, 7]
+     * - Prevents undefined behavior from over-shifting
+     * - Enhanced safety beyond standard requirements
+     */
+    template <typename IntegralType,
+              typename = std::enable_if_t<std::is_integral_v<IntegralType>>>
+    constexpr auto operator>>=(IntegralType shift) noexcept -> Byte&
+    {
+        if (!detail::is_constant_evaluated()) {
+            if (shift < 0 || shift >= 8) {
+                ara::core::Abort("Byte shift amount out of range [0, 7]");
+            }
+        }
+        value_ = static_cast<underlying_type>(
+            static_cast<underlying_type>(value_ >> (static_cast<unsigned>(shift) & 0x7u))
+        );
+        return *this;
+    }
+
+    /*!
+     * \brief Rejecting right shift assignment for non-integral types.
+     *
+     * \tparam T Non-integral type
+     * \param shift Invalid shift type (unused)
+     *
+     * \details
+     * - Provides clear compile-time error message
+     * - Prevents accidental misuse of shift assignment
+     */
+    template <typename T,
+              typename = std::enable_if_t<!std::is_integral_v<T>>,
+              int = 0>
+    constexpr auto operator>>=([[maybe_unused]] T shift) noexcept -> Byte&
+    {
+        static_assert(std::is_integral_v<T>,
+            "\n[ERROR] Cannot shift-assign ara::core::Byte with non-integral type!\n"
+            "        Shift amount must be an integral type.\n");
+        return *this;  // Never reached
+    }
+
+    // -----------------------------------------------------------------------------------
+    // ENHANCED FEATURES (BEYOND AUTOSAR)
+    // -----------------------------------------------------------------------------------
+    
+    /*!
+     * \brief Test if specific bit is set.
+     *
+     * \param pos Bit position to test [0, 7]
+     * \return true if bit is set, false otherwise
+     *
+     * \details
+     * - Enhanced API for bit manipulation
+     * - Bounds checked for safety
+     * - Modern C++ style interface
+     */
+    [[nodiscard]] constexpr auto test(std::size_t pos) const noexcept -> bool
+    {
+        if (pos >= 8) {
+            if (!detail::is_constant_evaluated()) {
+                ara::core::Abort("Bit position out of range [0, 7]");
+            }
+            return false;
+        }
+        return (value_ & static_cast<underlying_type>(1u << pos)) != 0;
+    }
+
+    /*!
+     * \brief Set specific bit to 1.
+     *
+     * \param pos Bit position to set [0, 7]
+     * \return Reference to this byte
+     *
+     * \details
+     * - Enhanced API for bit manipulation
+     * - Bounds checked for safety
+     * - Chainable operation
+     */
+    constexpr auto set(std::size_t pos) noexcept -> Byte&
+    {
+        if (pos >= 8) {
+            if (!detail::is_constant_evaluated()) {
+                ara::core::Abort("Bit position out of range [0, 7]");
+            }
+            return *this;
+        }
+        value_ = static_cast<underlying_type>(value_ | static_cast<underlying_type>(1u << pos));
+        return *this;
+    }
+
+    /*!
+     * \brief Reset specific bit to 0.
+     *
+     * \param pos Bit position to reset [0, 7]
+     * \return Reference to this byte
+     *
+     * \details
+     * - Enhanced API for bit manipulation
+     * - Bounds checked for safety
+     * - Chainable operation
+     */
+    constexpr auto reset(std::size_t pos) noexcept -> Byte&
+    {
+        if (pos >= 8) {
+            if (!detail::is_constant_evaluated()) {
+                ara::core::Abort("Bit position out of range [0, 7]");
+            }
+            return *this;
+        }
+        value_ = static_cast<underlying_type>(value_ & static_cast<underlying_type>(~(1u << pos)));
+        return *this;
+    }
+
+    /*!
+     * \brief Flip specific bit.
+     *
+     * \param pos Bit position to flip [0, 7]
+     * \return Reference to this byte
+     *
+     * \details
+     * - Enhanced API for bit manipulation
+     * - Bounds checked for safety
+     * - Chainable operation
+     */
+    constexpr auto flip(std::size_t pos) noexcept -> Byte&
+    {
+        if (pos >= 8) {
+            if (!detail::is_constant_evaluated()) {
+                ara::core::Abort("Bit position out of range [0, 7]");
+            }
+            return *this;
+        }
+        value_ = static_cast<underlying_type>(value_ ^ static_cast<underlying_type>(1u << pos));
+        return *this;
+    }
+
+    /*!
+     * \brief Set all bits to 1.
+     *
+     * \return Reference to this byte
+     */
+    constexpr auto set() noexcept -> Byte&
+    {
+        value_ = 0xFF;
+        return *this;
+    }
+
+    /*!
+     * \brief Reset all bits to 0.
+     *
+     * \return Reference to this byte
+     */
+    constexpr auto reset() noexcept -> Byte&
+    {
+        value_ = 0;
+        return *this;
+    }
+
+    /*!
+     * \brief Flip all bits.
+     *
+     * \return Reference to this byte
+     */
+    constexpr auto flip() noexcept -> Byte&
+    {
+        value_ = static_cast<underlying_type>(~value_);
+        return *this;
+    }
+
+    /*!
+     * \brief Count number of set bits (popcount).
+     *
+     * \return Number of bits set to 1
+     *
+     * \details
+     * - Enhanced feature for bit manipulation
+     * - Efficient implementation using bit tricks
+     * - Useful for embedded/systems programming
+     */
+    [[nodiscard]] constexpr auto count() const noexcept -> std::size_t
+    {
+        // Brian Kernighan's algorithm
+        std::size_t count = 0;
+        auto v = value_;
+        while (v) {
+            v = static_cast<underlying_type>(v & static_cast<underlying_type>(v - 1));
+            ++count;
+        }
+        return count;
+    }
+
+    /*!
+     * \brief Check if all bits are set.
+     *
+     * \return true if all bits are 1, false otherwise
+     */
+    [[nodiscard]] constexpr auto all() const noexcept -> bool
+    {
+        return value_ == 0xFF;
+    }
+
+    /*!
+     * \brief Check if any bit is set.
+     *
+     * \return true if at least one bit is 1, false otherwise
+     */
+    [[nodiscard]] constexpr auto any() const noexcept -> bool
+    {
+        return value_ != 0;
+    }
+
+    /*!
+     * \brief Check if no bits are set.
+     *
+     * \return true if all bits are 0, false otherwise
+     */
+    [[nodiscard]] constexpr auto none() const noexcept -> bool
+    {
+        return value_ == 0;
+    }
+
+private:
+
+    underlying_type value_;  /*!< Underlying storage - exactly 8 bits as per [SWS_CORE_10102] */
+
+    /*!
+     * \brief Trigger violation for out-of-range byte construction.
+     *
+     * \param location Source location information
+     * \param value The invalid value attempted
+     *
+     * \details
+     * - Uses AUTOSAR violation handler for consistency
+     * - Provides detailed error information
+     * - [[noreturn]] ensures proper compiler optimization
+     */
+    template <typename T>
+    [[noreturn]] static auto TriggerByteRangeViolation(
+        std::string_view location,
+        T value) noexcept -> void
+    {
+        auto& handler = ara::core::internal::ViolationHandler::Instance();
+        handler.TriggerByteRangeViolation(
+            ara::core::internal::ViolationHandler::ByteKey{},
+            location,
+            static_cast<long long>(value));
+    }
+};
+
+/**********************************************************************************************************************
+ *  NON-MEMBER FUNCTIONS - BITWISE OPERATORS
+ *********************************************************************************************************************/
+
+/*!
+ * \brief Bitwise AND operator.
+ *
+ * \param lhs Left operand
+ * \param rhs Right operand
+ * \return Result of bitwise AND
+ */
+[[nodiscard]] constexpr auto operator&(Byte lhs, Byte rhs) noexcept -> Byte
+{
+    return Byte{static_cast<std::uint8_t>(
+        static_cast<std::uint8_t>(lhs) & static_cast<std::uint8_t>(rhs))};
+}
+
+/*!
+ * \brief Bitwise OR operator.
+ *
+ * \param lhs Left operand
+ * \param rhs Right operand
+ * \return Result of bitwise OR
+ */
+[[nodiscard]] constexpr auto operator|(Byte lhs, Byte rhs) noexcept -> Byte
+{
+    return Byte{static_cast<std::uint8_t>(
+        static_cast<std::uint8_t>(lhs) | static_cast<std::uint8_t>(rhs))};
+}
+
+/*!
+ * \brief Bitwise XOR operator.
+ *
+ * \param lhs Left operand
+ * \param rhs Right operand
+ * \return Result of bitwise XOR
+ */
+[[nodiscard]] constexpr auto operator^(Byte lhs, Byte rhs) noexcept -> Byte
+{
+    return Byte{static_cast<std::uint8_t>(
+        static_cast<std::uint8_t>(lhs) ^ static_cast<std::uint8_t>(rhs))};
+}
+
+/*!
+ * \brief Bitwise NOT operator.
+ *
+ * \param b Operand to negate
+ * \return Result of bitwise NOT
+ */
+[[nodiscard]] constexpr auto operator~(Byte b) noexcept -> Byte
+{
+    return Byte{static_cast<std::uint8_t>(~static_cast<std::uint8_t>(b))};
+}
+
+/*!
+ * \brief Left shift operator.
+ *
+ * \param b Byte to shift
+ * \param shift Number of positions to shift
+ * \return Result of left shift
+ */
+template <typename IntegralType,
+          typename = std::enable_if_t<std::is_integral_v<IntegralType>>>
+[[nodiscard]] constexpr auto operator<<(Byte b, IntegralType shift) noexcept -> Byte
+{
+    return Byte{static_cast<std::uint8_t>(
+        static_cast<std::uint8_t>(b) << (static_cast<unsigned>(shift) & 0x7u))};
+}
+
+/*!
+ * \brief Rejecting left shift operator for non-integral shift amounts.
+ *
+ * \tparam T Non-integral type
+ * \param b Byte operand (unused)
+ * \param shift Invalid shift type (unused)
+ *
+ * \details
+ * - Provides clear compile-time error for invalid shift operations
+ * - Prevents accidental misuse of shift operators
+ */
+template <typename T,
+          typename = std::enable_if_t<!std::is_integral_v<T>>,
+          int = 0>
+[[nodiscard]] constexpr auto operator<<([[maybe_unused]] Byte b, [[maybe_unused]] T shift) noexcept -> Byte
+{
+    static_assert(std::is_integral_v<T>,
+        "\n[ERROR] Cannot shift ara::core::Byte by non-integral type!\n"
+        "        Shift amount must be an integral type.\n");
+    return Byte{0};  // Never reached
+}
+
+/*!
+ * \brief Right shift operator.
+ *
+ * \param b Byte to shift
+ * \param shift Number of positions to shift
+ * \return Result of right shift
+ */
+template <typename IntegralType,
+          typename = std::enable_if_t<std::is_integral_v<IntegralType>>>
+[[nodiscard]] constexpr auto operator>>(Byte b, IntegralType shift) noexcept -> Byte
+{
+    return Byte{static_cast<std::uint8_t>(
+        static_cast<std::uint8_t>(b) >> (static_cast<unsigned>(shift) & 0x7u))};
+}
+
+/*!
+ * \brief Rejecting right shift operator for non-integral shift amounts.
+ *
+ * \tparam T Non-integral type
+ * \param b Byte operand (unused)
+ * \param shift Invalid shift type (unused)
+ *
+ * \details
+ * - Provides clear compile-time error for invalid shift operations
+ * - Prevents accidental misuse of shift operators
+ */
+template <typename T,
+          typename = std::enable_if_t<!std::is_integral_v<T>>,
+          int = 0>
+[[nodiscard]] constexpr auto operator>>([[maybe_unused]] Byte b, [[maybe_unused]] T shift) noexcept -> Byte
+{
+    static_assert(std::is_integral_v<T>,
+        "\n[ERROR] Cannot shift ara::core::Byte by non-integral type!\n"
+        "        Shift amount must be an integral type.\n");
+    return Byte{0};  // Never reached
+}
+
+/**********************************************************************************************************************
+ *  NON-MEMBER FUNCTIONS - COMPARISON OPERATORS
+ *********************************************************************************************************************/
+
+/*!
+ * \brief Equality comparison operator.
+ *
+ * \param lhs Left operand
+ * \param rhs Right operand
+ * \return true if bytes are equal, false otherwise
+ */
+[[nodiscard]] constexpr auto operator==(Byte lhs, Byte rhs) noexcept -> bool
+{
+    return static_cast<std::uint8_t>(lhs) == static_cast<std::uint8_t>(rhs);
+}
+
+/*!
+ * \brief Inequality comparison operator.
+ *
+ * \param lhs Left operand
+ * \param rhs Right operand
+ * \return true if bytes are not equal, false otherwise
+ */
+[[nodiscard]] constexpr auto operator!=(Byte lhs, Byte rhs) noexcept -> bool
+{
+    return !(lhs == rhs);
+}
+
+/*!
+ * \brief Less-than comparison operator.
+ *
+ * \param lhs Left operand
+ * \param rhs Right operand
+ * \return true if lhs < rhs, false otherwise
+ */
+[[nodiscard]] constexpr auto operator<(Byte lhs, Byte rhs) noexcept -> bool
+{
+    return static_cast<std::uint8_t>(lhs) < static_cast<std::uint8_t>(rhs);
+}
+
+/*!
+ * \brief Less-than-or-equal comparison operator.
+ *
+ * \param lhs Left operand
+ * \param rhs Right operand
+ * \return true if lhs <= rhs, false otherwise
+ */
+[[nodiscard]] constexpr auto operator<=(Byte lhs, Byte rhs) noexcept -> bool
+{
+    return !(rhs < lhs);
+}
+
+/*!
+ * \brief Greater-than comparison operator.
+ *
+ * \param lhs Left operand
+ * \param rhs Right operand
+ * \return true if lhs > rhs, false otherwise
+ */
+[[nodiscard]] constexpr auto operator>(Byte lhs, Byte rhs) noexcept -> bool
+{
+    return rhs < lhs;
+}
+
+/*!
+ * \brief Greater-than-or-equal comparison operator.
+ *
+ * \param lhs Left operand
+ * \param rhs Right operand
+ * \return true if lhs >= rhs, false otherwise
+ */
+[[nodiscard]] constexpr auto operator>=(Byte lhs, Byte rhs) noexcept -> bool
+{
+    return !(lhs < rhs);
+}
+
+/**********************************************************************************************************************
+ *  SFINAE PROTECTION - PREVENTING INVALID OPERATIONS
+ *********************************************************************************************************************/
+
+/*!
+ * \brief Prevent comparison between Byte and other types (left variant).
+ *
+ * \tparam T Non-Byte type
+ * \param lhs Byte operand (unused)
+ * \param rhs Other type operand (unused)
+ *
+ * \details
+ * - Enforces [SWS_CORE_10107] - no implicit conversions
+ * - Provides clear compile-time error message
+ */
+template <typename T,
+          typename = std::enable_if_t<!std::is_same_v<T, Byte>>>
+constexpr auto operator==([[maybe_unused]] Byte lhs, [[maybe_unused]] const T& rhs) noexcept -> bool
+{
+    static_assert(std::is_same_v<T, Byte>,
+        "\n[ERROR] Cannot compare ara::core::Byte with other types!\n"
+        "        No implicit conversions are allowed for Byte comparisons.\n"
+        "        Use explicit casting if comparison is intended.\n");
+    return false;
+}
+
+/*!
+ * \brief Prevent comparison between Byte and other types (right variant).
+ *
+ * \tparam T Non-Byte type
+ * \param lhs Other type operand (unused)
+ * \param rhs Byte operand (unused)
+ */
+template <typename T,
+          typename = std::enable_if_t<!std::is_same_v<T, Byte>>>
+constexpr auto operator==([[maybe_unused]] const T& lhs, [[maybe_unused]] Byte rhs) noexcept -> bool
+{
+    static_assert(std::is_same_v<T, Byte>,
+        "\n[ERROR] Cannot compare ara::core::Byte with other types!\n"
+        "        No implicit conversions are allowed for Byte comparisons.\n"
+        "        Use explicit casting if comparison is intended.\n");
+    return false;
+}
+
+/*!
+ * \brief Prevent bitwise operations between Byte and other types (AND).
+ *
+ * \tparam T Non-Byte type
+ * \param lhs Byte operand (unused)
+ * \param rhs Other type operand (unused)
+ */
+template <typename T,
+          typename = std::enable_if_t<!std::is_same_v<T, Byte>>>
+constexpr auto operator&([[maybe_unused]] Byte lhs, [[maybe_unused]] const T& rhs) noexcept -> Byte
+{
+    static_assert(std::is_same_v<T, Byte>,
+        "\n[ERROR] Cannot perform bitwise AND between ara::core::Byte and other types!\n"
+        "        Bitwise operations require both operands to be Byte.\n"
+        "        Use explicit Byte construction for the other operand.\n");
+    return Byte{0};
+}
+
+/*!
+ * \brief Prevent bitwise operations between Byte and other types (OR).
+ *
+ * \tparam T Non-Byte type
+ * \param lhs Byte operand (unused)
+ * \param rhs Other type operand (unused)
+ */
+template <typename T,
+          typename = std::enable_if_t<!std::is_same_v<T, Byte>>>
+constexpr auto operator|([[maybe_unused]] Byte lhs, [[maybe_unused]] const T& rhs) noexcept -> Byte
+{
+    static_assert(std::is_same_v<T, Byte>,
+        "\n[ERROR] Cannot perform bitwise OR between ara::core::Byte and other types!\n"
+        "        Bitwise operations require both operands to be Byte.\n"
+        "        Use explicit Byte construction for the other operand.\n");
+    return Byte{0};
+}
+
+/*!
+ * \brief Prevent bitwise operations between Byte and other types (XOR).
+ *
+ * \tparam T Non-Byte type
+ * \param lhs Byte operand (unused)
+ * \param rhs Other type operand (unused)
+ */
+template <typename T,
+          typename = std::enable_if_t<!std::is_same_v<T, Byte>>>
+constexpr auto operator^([[maybe_unused]] Byte lhs, [[maybe_unused]] const T& rhs) noexcept -> Byte
+{
+    static_assert(std::is_same_v<T, Byte>,
+        "\n[ERROR] Cannot perform bitwise XOR between ara::core::Byte and other types!\n"
+        "        Bitwise operations require both operands to be Byte.\n"
+        "        Use explicit Byte construction for the other operand.\n");
+    return Byte{0};
+}
+
+/*!
+ * \brief Prevent arithmetic addition with Byte.
+ *
+ * \param lhs Left operand (unused)
+ * \param rhs Right operand (unused)
+ */
+constexpr auto operator+([[maybe_unused]] Byte lhs, [[maybe_unused]] Byte rhs) noexcept -> Byte = delete;
+
+/*!
+ * \brief Prevent arithmetic subtraction with Byte.
+ *
+ * \param lhs Left operand (unused)
+ * \param rhs Right operand (unused)
+ */
+constexpr auto operator-([[maybe_unused]] Byte lhs, [[maybe_unused]] Byte rhs) noexcept -> Byte = delete;
+
+/*!
+ * \brief Prevent arithmetic multiplication with Byte.
+ *
+ * \param lhs Left operand (unused)
+ * \param rhs Right operand (unused)
+ */
+constexpr auto operator*([[maybe_unused]] Byte lhs, [[maybe_unused]] Byte rhs) noexcept -> Byte = delete;
+
+/*!
+ * \brief Prevent arithmetic division with Byte.
+ *
+ * \param lhs Left operand (unused)
+ * \param rhs Right operand (unused)
+ */
+constexpr auto operator/([[maybe_unused]] Byte lhs, [[maybe_unused]] Byte rhs) noexcept -> Byte = delete;
+
+/*!
+ * \brief Prevent arithmetic modulo with Byte.
+ *
+ * \param lhs Left operand (unused)
+ * \param rhs Right operand (unused)
+ */
+constexpr auto operator%([[maybe_unused]] Byte lhs, [[maybe_unused]] Byte rhs) noexcept -> Byte = delete;
+
+/**********************************************************************************************************************
+ *  NON-MEMBER FUNCTIONS - UTILITY FUNCTIONS
+ *********************************************************************************************************************/
+
+/*!
+ * \brief Convert integer to Byte with explicit notation.
+ *
+ * \tparam IntegralType Type of the integral value
+ * \param value The value to convert
+ * \return Byte representation of the value
+ *
+ * \details
+ * - Factory function for clearer code
+ * - Alternative to constructor for readability
+ * - Enhanced beyond AUTOSAR for better API
+ */
+template <typename IntegralType,
+          typename = std::enable_if_t<std::is_integral_v<IntegralType>>>
+[[nodiscard]] constexpr auto to_byte(IntegralType value) noexcept -> Byte
+{
+    return Byte{value};
+}
+
+/*!
+ * \brief Rejecting to_byte for non-integral types.
+ *
+ * \tparam T Non-integral type
+ * \param value Invalid value type (unused)
+ *
+ * \details
+ * - Provides clear compile-time error message
+ * - Enforces type safety for byte creation
+ */
+template <typename T,
+          typename = std::enable_if_t<!std::is_integral_v<T> && !std::is_same_v<T, char>>,
+          int = 0>
+[[nodiscard]] constexpr auto to_byte([[maybe_unused]] T value) noexcept -> Byte
+{
+    static_assert(std::is_integral_v<T> || std::is_same_v<T, char>,
+        "\n[ERROR] Cannot convert non-integral type to ara::core::Byte!\n"
+        "        to_byte() only accepts integral types or char.\n"
+        "        Use explicit casting if conversion is intended.\n");
+    return Byte{0};  // Never reached
+}
+
+/*!
+ * \brief Create Byte from character literal.
+ *
+ * \param c Character to convert
+ * \return Byte representation of the character
+ *
+ * \details
+ * - Convenience function for character data
+ * - Common use case in protocol implementations
+ * - Enhanced API feature
+ */
+[[nodiscard]] constexpr auto to_byte(char c) noexcept -> Byte
+{
+    return Byte{static_cast<unsigned char>(c)};
+}
+
+/**********************************************************************************************************************
+ *  NON-MEMBER FUNCTIONS - ENHANCED INTEGER LITERAL SUPPORT (C++26-like)
+ *********************************************************************************************************************/
+
+/*!
+ * \brief User-defined literal for Byte creation.
+ *
+ * \tparam Chars Character pack representing the literal
+ * \return Byte value from the literal
+ *
+ * \details
+ * - Enables syntax like: auto b = 0xFF_byte;
+ * - Compile-time parsing and validation
+ * - Enhanced feature inspired by C++26 proposals
+ * - Supports decimal, hex (0x), octal (0), and binary (0b) literals
+ */
+namespace literals {
+namespace byte_literals {
+
+namespace detail {
+
+/* template-dependent false for assertions */
+template<char... Cs> struct always_false : std::false_type {};
+
+/* sentinel codes (must all be >255) */
+constexpr std::uint16_t INVALID_DIGIT = 0x1FF;
+constexpr std::uint16_t OVERFLOW      = 0x1FE;
+constexpr std::uint16_t NO_DIGITS     = 0x1FD;
+
+template<char... Cs>
+struct parse_byte
+{
+private:
+    static constexpr std::uint16_t compute() noexcept
+    {
+        constexpr char txt[] { Cs..., '\0' };
+        constexpr std::size_t n = sizeof...(Cs);
+
+        std::size_t pos = 0;
+        int base        = 10;
+
+        /* prefix handling --------------------------------------------------*/
+        if (n >= 2 && txt[0] == '0')
+        {
+            switch (txt[1]) {
+                case 'x': case 'X': base = 16; pos = 2; break;
+                case 'b': case 'B': base =  2; pos = 2; break;
+                default:            base =  8; pos = 1; break; // 0-leading
+            }
+        }
+
+        auto digit = [](char c) constexpr -> int {
+            return (c >= '0' && c <= '9') ? c - '0' :
+                   (c >= 'a' && c <= 'f') ? 10 + c - 'a' :
+                   (c >= 'A' && c <= 'F') ? 10 + c - 'A' : -1;
+        };
+
+        std::uint16_t val = 0;
+        bool have_digit   = false;
+
+        for (; pos < n; ++pos)
+        {
+            int d = digit(txt[pos]);
+            if (d < 0 || d >= base)           return INVALID_DIGIT;
+            val = static_cast<std::uint16_t>(val * base + d);
+            if (val > 255)                    return OVERFLOW;
+            have_digit = true;
+        }
+        return have_digit ? val : NO_DIGITS;
+    }
+
+public:
+    static constexpr std::uint16_t raw = compute();
+
+    /* one assert per failure-code – evaluated exactly once per literal -----*/
+    static_assert(raw != INVALID_DIGIT,
+        "\n[ERROR] invalid digit for chosen base in _byte literal");
+    static_assert(raw != OVERFLOW,
+        "\n[ERROR] _byte literal value exceeds 255");
+    static_assert(raw != NO_DIGITS,
+        "\n[ERROR] _byte literal contains no digits after the prefix");
+
+    static constexpr std::uint8_t value =
+        static_cast<std::uint8_t>(raw);   // safe: raw is 0-255
+};
+
+} // namespace detail
+
+/* user-defined literal ------------------------------------------------------*/
+template<char... Cs>
+[[nodiscard]] constexpr ara::core::Byte operator ""_byte() noexcept
+{
+    return ara::core::Byte{ detail::parse_byte<Cs...>::value };
+}
+
+} // namespace byte_literals
+} // namespace literals
+
+// Bring byte literals into ara::core namespace for convenience
+
+/**********************************************************************************************************************
+ *  STREAM OPERATORS (ENHANCED FEATURE)
+ *********************************************************************************************************************/
+
+#ifdef ARA_CORE_BYTE_ENABLE_IOSTREAM
+#include <iostream>
+#include <iomanip>
+
+/*!
+ * \brief Stream insertion operator for debugging.
+ *
+ * \param os Output stream
+ * \param b Byte to output
+ * \return Reference to the stream
+ *
+ * \details
+ * - Outputs byte as hex value (e.g., "0xFF")
+ * - Enhanced feature for debugging and logging
+ * - Not required by AUTOSAR but useful in practice
+ * - Note: Cannot be constexpr due to I/O operations
+ *
+ * \note Conditional compilation based on ARA_CORE_BYTE_ENABLE_IOSTREAM
+ */
+inline auto operator<<(std::ostream& os, Byte b) -> std::ostream&
+{
+    const auto saved_flags = os.flags();
+    const auto saved_fill = os.fill();
+    
+    os << "0x" << std::hex << std::uppercase << std::setfill('0') 
+       << std::setw(2) << static_cast<unsigned>(static_cast<std::uint8_t>(b));
+    
+    // Restore stream state
+    os.flags(saved_flags);
+    os.fill(saved_fill);
+    
+    return os;
+}
+#endif
+
+/**********************************************************************************************************************
+ *  TYPE TRAITS SUPPORT
+ *********************************************************************************************************************/
+
+} // namespace core
+} // namespace ara
+
+// Type traits specializations in std namespace
+namespace std {
+
+/*!
+ * \brief Specialize numeric_limits for ara::core::Byte.
+ *
+ * \details
+ * - Provides standard numeric properties
+ * - Enhanced feature for generic programming
+ * - Enables use in template algorithms
+ */
+template <>
+class numeric_limits<ara::core::Byte> {
+public:
+    static constexpr bool is_specialized = true;
+    static constexpr bool is_signed = false;
+    static constexpr bool is_integer = true;
+    static constexpr bool is_exact = true;
+    static constexpr bool has_infinity = false;
+    static constexpr bool has_quiet_NaN = false;
+    static constexpr bool has_signaling_NaN = false;
+    static constexpr std::float_denorm_style has_denorm = std::denorm_absent;
+    static constexpr bool has_denorm_loss = false;
+    static constexpr std::float_round_style round_style = std::round_toward_zero;
+    static constexpr bool is_iec559 = false;
+    static constexpr bool is_bounded = true;
+    static constexpr bool is_modulo = true;
+    static constexpr int digits = 8;
+    static constexpr int digits10 = 2;
+    static constexpr int max_digits10 = 0;
+    static constexpr int radix = 2;
+    static constexpr int min_exponent = 0;
+    static constexpr int min_exponent10 = 0;
+    static constexpr int max_exponent = 0;
+    static constexpr int max_exponent10 = 0;
+    static constexpr bool traps = false;
+    static constexpr bool tinyness_before = false;
+
+    static constexpr auto min() noexcept -> ara::core::Byte { 
+        return ara::core::Byte{0}; 
+    }
+    
+    static constexpr auto lowest() noexcept -> ara::core::Byte { 
+        return ara::core::Byte{0}; 
+    }
+    
+    static constexpr auto max() noexcept -> ara::core::Byte { 
+        return ara::core::Byte{255}; 
+    }
+    
+    static constexpr auto epsilon() noexcept -> ara::core::Byte { 
+        return ara::core::Byte{0}; 
+    }
+    
+    static constexpr auto round_error() noexcept -> ara::core::Byte { 
+        return ara::core::Byte{0}; 
+    }
+    
+    static constexpr auto infinity() noexcept -> ara::core::Byte { 
+        return ara::core::Byte{0}; 
+    }
+    
+    static constexpr auto quiet_NaN() noexcept -> ara::core::Byte { 
+        return ara::core::Byte{0}; 
+    }
+    
+    static constexpr auto signaling_NaN() noexcept -> ara::core::Byte { 
+        return ara::core::Byte{0}; 
+    }
+    
+    static constexpr auto denorm_min() noexcept -> ara::core::Byte { 
+        return ara::core::Byte{0}; 
+    }
+};
+
+} // namespace std
+
+/**********************************************************************************************************************
+ *  COMPILE-TIME VERIFICATION
+ *********************************************************************************************************************/
+/*!
+ * \brief Compile-time verification of AUTOSAR requirements for ara::core::Byte
+ * 
+ * \details How these static assertions work:
+ * 
+ * 1. **Placement after class definition**: These assertions are placed AFTER the complete
+ *    definition of the Byte class. This is crucial because the compiler needs the full
+ *    class definition to evaluate type traits.
+ * 
+ * 2. **Type trait evaluation**: The compiler evaluates these at compile time:
+ *    - sizeof(Byte): Checks the actual memory size of the class
+ *    - is_trivially_default_constructible: Verifies Byte() = default is trivial
+ *    - is_trivially_destructible: Verifies ~Byte() = default is trivial
+ *    - is_standard_layout: Ensures no virtual functions, single access control, etc.
+ * 
+ * 3. **Conversion checks**: 
+ *    - is_convertible<int, Byte>: Would be true if you could write: Byte b = 42;
+ *    - Since constructor is explicit, this is false (good!)
+ *    - is_convertible<Byte, int>: Would be true if you could write: int i = someByte;
+ *    - Since conversion operator is explicit, this is false (good!)
+ * 
+ * 4. **Compile-time guarantee**: If ANY of these assertions fail, compilation stops
+ *    immediately with the specified error message, preventing non-compliant code from
+ *    being built.
+ * 
+ * Example of what makes these work:
+ * - Making constructor explicit prevents: is_convertible<int, Byte> 
+ * - Using = default for destructor ensures: is_trivially_destructible
+ * - Having only one data member (value_) helps ensure: is_standard_layout
+ */
+
+namespace ara {
+namespace core {
+
+// Verify that ara::core::Byte meets all AUTOSAR requirements
+static_assert(sizeof(Byte) == 1, 
+    "ara::core::Byte must be exactly 1 byte in size [SWS_CORE_10102]");
+
+static_assert(std::is_trivially_default_constructible_v<Byte>,
+    "ara::core::Byte must be trivially default constructible [SWS_CORE_10104]");
+
+static_assert(std::is_trivially_destructible_v<Byte>,
+    "ara::core::Byte must have trivial destructor [SWS_CORE_10105]");
+
+static_assert(std::is_trivially_copy_constructible_v<Byte>,
+    "ara::core::Byte must be trivially copy constructible");
+
+static_assert(std::is_trivially_move_constructible_v<Byte>,
+    "ara::core::Byte must be trivially move constructible");
+
+static_assert(std::is_standard_layout_v<Byte>,
+    "ara::core::Byte must have standard layout");
+
+static_assert(!std::is_convertible_v<int, Byte>,
+    "ara::core::Byte must not be implicitly convertible from other types [SWS_CORE_10106]");
+
+static_assert(!std::is_convertible_v<Byte, int>,
+    "ara::core::Byte must not be implicitly convertible to other types [SWS_CORE_10107]");
+
+static_assert(!std::is_convertible_v<Byte, bool>,
+    "ara::core::Byte must not be implicitly convertible to bool [SWS_CORE_10107]");
+
+} // namespace core
+} // namespace ara
+
+#endif // OPEN_AA_ADAPTIVE_AUTOSAR_LIBS_INCLUDE_ARA_CORE_BYTE_H_

--- a/components/open-aa-std-adaptive-autosar-libs/include/ara/core/internal/utility.h
+++ b/components/open-aa-std-adaptive-autosar-libs/include/ara/core/internal/utility.h
@@ -30,6 +30,24 @@ namespace ara::core {
 template <typename T, std::size_t N>
 class Array;    
 
+/*!
+ * \brief  Forward declaration of the get function template.
+ */
+template <std::size_t I, typename T, std::size_t N>
+constexpr auto get(ara::core::Array<T,N>&) noexcept -> T&;
+
+/*!
+ * \brief  Forward declaration of the get function template.
+ */
+template <std::size_t I, typename T, std::size_t N>
+constexpr auto get(const ara::core::Array<T,N>&) noexcept -> const T&;
+
+/*!
+ * \brief  Forward declaration of the get function template.
+ */
+template <std::size_t I, typename T, std::size_t N>
+constexpr auto get(ara::core::Array<T,N>&&) noexcept -> T&&;
+
 } // namespace ara::core
 
 
@@ -107,6 +125,90 @@ inline std::mutex g_abortMutex{};
     #else
         return false;                                     // fallback: always run-time
     #endif
+}
+
+
+/***********************************************************************************************************************
+ *  INTERNAL: IS_TUPLE_LIKE
+ ***********************************************************************************************************************/
+/*!
+ * \brief  Trait to detect if a type is tuple-like.
+ *
+ * This trait checks if the type T has a valid std::tuple_size specialization,
+ * indicating that it behaves like a tuple.
+ *
+ * \tparam T The type to check.
+ */
+template<typename T, typename = void>
+struct is_tuple_like : std::false_type {};
+
+template<typename T>
+struct is_tuple_like<T,
+        std::void_t< decltype(std::tuple_size<std::remove_cv_t<T>>::value) >>
+      : std::true_type {};
+
+template<typename T>
+inline constexpr bool is_tuple_like_v = is_tuple_like<T>::value;
+
+
+/*!
+ * \brief  Converts a tuple-like type to a std::tuple.
+ *
+ * This function template converts a tuple-like type (e.g., ara::core::Array)
+ * into a std::tuple, preserving the types of its elements.
+ *
+ * \tparam Src The source tuple-like type to convert.
+ * \param src The source tuple-like object to convert.
+ * \return A std::tuple containing the elements of the source object.
+ */
+template<typename Src, std::size_t... I>
+constexpr auto to_std_tuple_impl(Src&& src, std::index_sequence<I...>)
+{
+    /* unqualified get -> ADL; NO ‘using std::get;’ */
+    return std::tuple< std::decay_t<decltype(get<I>(src))>... >{
+               get<I>(std::forward<Src>(src))... };
+}
+
+/*!
+ * \brief  Converts a tuple-like type to a std::tuple.
+ *
+ * This function template converts a tuple-like type (e.g., ara::core::Array)
+ * into a std::tuple, preserving the types of its elements.
+ *
+ * \tparam Src The source tuple-like type to convert.
+ * \param src The source tuple-like object to convert.
+ * \return A std::tuple containing the elements of the source object.
+ */
+template<typename Src>
+constexpr auto to_std_tuple(Src&& src)
+{
+    constexpr std::size_t N =
+        std::tuple_size_v<std::remove_cv_t<std::remove_reference_t<Src>>>;
+    return to_std_tuple_impl(std::forward<Src>(src),
+                             std::make_index_sequence<N>{});
+}
+
+/*!
+ * \brief  Helper function to apply a callable to the elements of a tuple-like object.
+ *
+ * This function forwards the callable and the tuple-like object, expanding the
+ * tuple-like object's elements as arguments to the callable.
+ *
+ * \tparam F     The type of the callable (function, lambda, etc.).
+ * \tparam Tuple The type of the tuple-like object.
+ * \tparam I     The index sequence for unpacking the tuple-like object's elements.
+ *
+ * \param f   The callable to apply.
+ * \param tup The tuple-like object containing the elements to pass to the callable.
+ * \return    The result of calling f with the unpacked elements of tup.
+ */
+template<typename F, typename Tuple, std::size_t... I>
+constexpr decltype(auto) apply_impl(F&& f,
+                                    Tuple&& tup,
+                                    std::index_sequence<I...>)
+{
+    /* again: unqualified get – ADL only */
+    return std::forward<F>(f)( get<I>(std::forward<Tuple>(tup))... );
 }
 
 /*!

--- a/components/open-aa-std-adaptive-autosar-libs/include/ara/core/internal/utility.h
+++ b/components/open-aa-std-adaptive-autosar-libs/include/ara/core/internal/utility.h
@@ -212,6 +212,26 @@ constexpr decltype(auto) apply_impl(F&& f,
 }
 
 /*!
+ * \brief  Helper to implement to_array for lvalue arrays.
+ */
+template <typename T, std::size_t N, std::size_t... I>
+constexpr auto to_array_impl(T (&a)[N], std::index_sequence<I...>) 
+    noexcept(std::is_nothrow_copy_constructible_v<T>) -> Array<T, N>
+{
+    return {{a[I]...}};
+}
+
+/*!
+ * \brief  Helper to implement to_array for rvalue arrays.
+ */
+template <typename T, std::size_t N, std::size_t... I>
+constexpr auto to_array_impl(T (&&a)[N], std::index_sequence<I...>) 
+    noexcept(std::is_nothrow_move_constructible_v<T>) -> Array<T, N>
+{
+    return {{std::move(a[I])...}};
+}
+
+/*!
  * \brief Trait to detect whether an array of type T[N] can be list‑initialized
  *        with arguments of types Args... without narrowing conversions.
  *
@@ -430,14 +450,14 @@ protected:
     template <typename... Args,
               typename = std::enable_if_t<(sizeof...(Args) > 0)>>
     constexpr ArrayStorage(Args&&... args)
-#ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
         noexcept(std::conjunction_v<std::is_nothrow_constructible<T, Args&&>...>)
 #else
         noexcept
 #endif
         : data_{std::forward<Args>(args)...} 
     {
-#ifndef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+#ifndef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
         static_assert(std::conjunction_v<std::is_nothrow_constructible<T, Args&&>...>,
             "\n[ERROR] in ara::core::Array: The type T and args must be noexcept.\n");
 #endif  

--- a/components/open-aa-std-adaptive-autosar-libs/include/ara/core/internal/violation_handler.h
+++ b/components/open-aa-std-adaptive-autosar-libs/include/ara/core/internal/violation_handler.h
@@ -37,6 +37,8 @@ namespace core {
 template <typename T, std::size_t N>
 class Array;
 
+class Byte; // Forward declaration of the Byte class
+
 namespace internal {
 
 /**********************************************************************************************************************
@@ -88,6 +90,31 @@ public:
             friend class ara::core::Array;
     };
 
+    struct ByteKey{
+        constexpr ByteKey(const ByteKey&) noexcept = delete;
+        constexpr ByteKey(ByteKey&&) noexcept = delete;
+        constexpr auto operator=(const ByteKey&) noexcept = delete;
+        constexpr auto operator=(ByteKey&&) noexcept = delete;
+        ~ByteKey() = default;
+
+        private:
+            /*!
+             * \brief  Private constructor to prevent instantiation.
+             *
+             * \details
+             * This constructor is private to ensure that the ByteKey cannot be instantiated outside of this class.
+             */
+            constexpr ByteKey() noexcept {
+                // This constructor is intentionally left empty.
+            };
+            /*!
+             * \brief  Grants friendship to the ara::core::Byte class to allow exclusive access.
+             *
+             * \note   Ensures that ara::core::Byte allowed trigger violations.
+             */
+            friend class ara::core::Byte;
+    };
+
     /*!
      * \brief  Retrieves the singleton instance of ViolationHandler.
      *
@@ -115,6 +142,23 @@ public:
                                                std::string_view location,
                                                std::size_t indexValue,
                                                std::size_t arraySize) noexcept -> void;
+
+    /*!
+     * \brief  Triggers a ByteRangeViolation.
+     *
+     * \param  location   An implementation-defined identifier of the location where the violation was detected
+     *                    (e.g., "file.cpp:123").
+     * \param  value      The invalid value that caused the violation.
+     *
+     * \details
+     * Logs a violation message and terminates the process abnormally as per [SWS_CORE_00090]. This method is noexcept
+     * and does not throw exceptions.
+     *
+     * \note   [SWS_CORE_00090]
+     */
+    [[noreturn]] auto TriggerByteRangeViolation(ByteKey&& /*unused*/,
+                                                std::string_view location,
+                                                long long value) noexcept -> void;
 
 
 private:

--- a/components/open-aa-std-adaptive-autosar-libs/include/ara/core/span.h
+++ b/components/open-aa-std-adaptive-autosar-libs/include/ara/core/span.h
@@ -22,9 +22,9 @@
 
 #include <cstddef>               // For std::size_t
 #include <limits>                // For std::numeric_limits
-#include <type_traits>          // For std::remove_cv_t, std::is_same_v
-#include <iterator>             // For std::reverse_iterator
-#include <utility>              // For std::forward, std::declval
+#include <type_traits>           // For std::remove_cv_t, std::is_same_v
+#include <iterator>              // For std::reverse_iterator
+#include <utility>               // For std::forward, std::declval
 
 
 namespace ara {
@@ -71,8 +71,106 @@ public:
 
     static constexpr size_type extent = Extent;                            /*!< [SWS_CORE_01931] The size of the span, or dynamic_extent if dynamic.      */
 
-    constexpr Span(const Span& other) noexcept = default;                  /*!< [SWS_CORE_01949] Copy constructor.                                         */
 
+    /*! \brief  Default constructor for Span.
+     *
+     * This constructor initializes an empty span with no elements.
+     * It is equivalent to a span of size 0.
+     *
+     * \note [SWS_CORE_01940] Default constructor initializes an empty span.
+     */
+    constexpr Span(const Span& other) noexcept = default;  
+    
+    /*! \brief  Default constructor for Span.
+     *
+     * This constructor initializes an empty span with no elements.
+     * It is equivalent to a span of size 0.
+     *
+     * \note [SWS_CORE_01941] Default constructor.
+     * \note This constructor only participates in overload resolution when:
+     *       (Extent == dynamic_extent || Extent == 0) is true
+     */
+    template <typename = std::enable_if_t<Extent == dynamic_extent || Extent == 0>>
+    constexpr Span() noexcept 
+        : data_{nullptr}, size_{0} 
+    {
+    }
+
+    /*! \brief SFINAE constructor for invalid default construction.
+     *
+     * \note This constructor only participates in overload resolution when:
+     *       - Extent != dynamic_extent && Extent != 0
+     */
+    template <typename T_ = T,
+              typename = std::enable_if_t<Extent != dynamic_extent && Extent != 0>,
+              typename = void>  // Extra dummy parameter to make signature different
+    constexpr Span() noexcept
+    {
+        static_assert(Extent == dynamic_extent || Extent == 0,
+             "\n[ERROR] Cannot default construct Span<T, Extent> when Extent is neither dynamic_extent nor 0.\n"
+             "A static extent span with size > 0 must be initialized with data.\n");
+    }
+
+    
+    constexpr auto operator=(const Span& other) noexcept -> Span& = default;
+
+    /*! \brief  Converting constructor for compatible Span types.
+     *
+     * This constructor allows construction of a cv-qualified Span from a normal Span,
+     * and also of a dynamic_extent Span from a static extent one.
+     * 
+     * \tparam U The type of elements within the other Span.
+     * \tparam N The Extent of the other Span.
+     * \param other The other Span instance to convert from.
+     *
+     * \note [SWS_CORE_01950] Converting constructor.
+     * \note This constructor only participates in overload resolution when:
+     *       - Extent == dynamic_extent || Extent == N is true
+     *       - U(*)[] is convertible to T(*)[]
+     *
+     * \details Enables conversions like:
+     *          - Span<int, 5> to Span<int> (static to dynamic)
+     *          - Span<int, 5> to Span<const int, 5> (add const qualification)
+     *          - Span<int> to Span<const int> (add const qualification)
+     */
+    template <typename U, std::size_t N,
+              typename = std::enable_if_t<
+                  (Extent == dynamic_extent || Extent == N) &&
+                  std::is_convertible_v<U(*)[], T(*)[]>
+              >>
+    constexpr Span(const Span<U, N>& other) noexcept
+        : data_{other.data_}, size_{other.size_}
+        {
+
+        }
+    
+
+    /*! \brief SFINAE constructor for converting Span types.
+     *
+     * \tparam U The type of elements within the other Span.
+     * \tparam N The Extent of the other Span.
+     * \note This constructor only participates in overload resolution when:
+     *       - Extent != dynamic_extent && Extent != N
+     *       - U(*)[] is not convertible to T(*)[]
+     */
+    template <typename U, std::size_t N,
+              typename = std::enable_if_t<!((Extent == dynamic_extent || Extent == N) && std::is_convertible_v<U(*)[], T(*)[]>)>,
+              typename = void>  // Extra dummy parameter to make signature different
+    constexpr Span(const Span<U, N>& /*other*/) noexcept
+        {
+            static_assert(Extent == dynamic_extent || Extent == N,
+                 "\n[ERROR] Cannot convert Span<U, N> to Span<T, Extent> when Extent is not dynamic_extent or N.\n");
+            
+            static_assert(std::is_convertible_v<U(*)[], T(*)[]>,
+                 "\n[ERROR] Cannot convert Span<U, N> to Span<T, Extent> when U is not convertible to T.\n");     
+        }
+
+    
+
+private:
+
+    pointer data_;                                                      
+    size_type size_;                                                    
 
 };
 
@@ -107,7 +205,7 @@ constexpr auto MakeSpan(T* ptr, typename Span<T>::size_type size) noexcept -> Sp
  */
 template <typename T>
 constexpr auto MakeSpan(T* firstElem, T* lastElem) noexcept -> Span<T> {
-    return Span<T>(firstElem, lastElem - firstElem);
+    return Span<T>(firstElem, lastElem);
 }
 
 /*! \brief  Creates a span from an array.
@@ -119,8 +217,8 @@ constexpr auto MakeSpan(T* firstElem, T* lastElem) noexcept -> Span<T> {
  * \note   [SWS_CORE_01992] This function is a convenience wrapper to create a span from an array.
  */
 template <typename T, std::size_t N>
-constexpr auto MakeSpan(T(&arr)[N]) noexcept -> Span<T> {
-    return Span<T>(arr, N);
+constexpr auto MakeSpan(T(&arr)[N]) noexcept -> Span<T, N> {
+    return Span<T, N>(arr, N);
 }
 
 /*! \brief  Creates a span from a container.
@@ -149,33 +247,33 @@ constexpr auto MakeSpan(const Container& cont) noexcept -> Span<typename Contain
     return Span<typename Container::value_type const>(cont.data(), cont.size());
 }
 
-/*! \brief  Converts a span of elements to a span of bytes.
- *
- * \tparam ElementType The type of elements in the span.
- * \tparam Extent The size of the span (or dynamic_extent for dynamic size).
- * \param s The span to convert.
- * \return A span of bytes representing the same data as the original span.
- *
- * \note   [SWS_CORE_01980] This function is used to reinterpret the data in a span as bytes.
- */
-template <typename ElementType, std::size Extent>
-auto as_bytes(Span<ElementType, Extent> s) noexcept -> Span<const Byte, Extent==dynamic_extent? dynamic_extent : Extent * sizeof(ElementType)> {
-    return Span<const Byte, Extent==dynamic_extent? dynamic_extent : Extent * sizeof(ElementType)>(reinterpret_cast<const Byte*>(s.data()), s.size_bytes());
-}
+// /*! \brief  Converts a span of elements to a span of bytes.
+//  *
+//  * \tparam ElementType The type of elements in the span.
+//  * \tparam Extent The size of the span (or dynamic_extent for dynamic size).
+//  * \param s The span to convert.
+//  * \return A span of bytes representing the same data as the original span.
+//  *
+//  * \note   [SWS_CORE_01980] This function is used to reinterpret the data in a span as bytes.
+//  */
+// template <typename ElementType, std::size Extent>
+// auto as_bytes(Span<ElementType, Extent> s) noexcept -> Span<const Byte, Extent==dynamic_extent? dynamic_extent : Extent * sizeof(ElementType)> {
+//     return Span<const Byte, Extent==dynamic_extent? dynamic_extent : Extent * sizeof(ElementType)>(reinterpret_cast<const Byte*>(s.data()), s.size_bytes());
+// }
 
-/*! \brief  Converts a span of elements to a writable span of bytes.
- *
- * \tparam ElementType The type of elements in the span.
- * \tparam Extent The size of the span (or dynamic_extent for dynamic size).
- * \param s The span to convert.
- * \return A writable span of bytes representing the same data as the original span.
- *
- * \note   [SWS_CORE_01981] This function is used to reinterpret the data in a span as writable bytes.
- */
-template <typename ElementType, std::size Extent>
-auto as_writable_bytes(Span<ElementType, Extent> s) noexcept -> Span<Byte, Extent==dynamic_extent? dynamic_extent : Extent * sizeof(ElementType)> {
-    return Span<Byte, Extent==dynamic_extent? dynamic_extent : Extent * sizeof(ElementType)>(reinterpret_cast<Byte*>(s.data()), s.size_bytes());
-}
+// /*! \brief  Converts a span of elements to a writable span of bytes.
+//  *
+//  * \tparam ElementType The type of elements in the span.
+//  * \tparam Extent The size of the span (or dynamic_extent for dynamic size).
+//  * \param s The span to convert.
+//  * \return A writable span of bytes representing the same data as the original span.
+//  *
+//  * \note   [SWS_CORE_01981] This function is used to reinterpret the data in a span as writable bytes.
+//  */
+// template <typename ElementType, std::size Extent>
+// auto as_writable_bytes(Span<ElementType, Extent> s) noexcept -> Span<Byte, Extent==dynamic_extent? dynamic_extent : Extent * sizeof(ElementType)> {
+//     return Span<Byte, Extent==dynamic_extent? dynamic_extent : Extent * sizeof(ElementType)>(reinterpret_cast<Byte*>(s.data()), s.size_bytes());
+// }
 
 } // namespace core
 } // namespace ara

--- a/components/open-aa-std-adaptive-autosar-libs/include/ara/core/span.h
+++ b/components/open-aa-std-adaptive-autosar-libs/include/ara/core/span.h
@@ -1,0 +1,183 @@
+/**********************************************************************************************************************
+ *  PROJECT
+ *  -------------------------------------------------------------------------------------------------------------------
+ *  \verbatim
+ *  OpenAA: Open Source Adaptive AUTOSAR Project (CXX_STANDARD 17)
+ *  Author: Sherif Mohamed
+ *  \endverbatim
+ *  -------------------------------------------------------------------------------------------------------------------
+ *  FILE DESCRIPTION
+ *  -------------------------------------------------------------------------------------------------------------------
+ *  \file       ara/core/span.h
+ *  \brief      Definition and implementation of the ara::core::Span template class.
+ *
+ *  \details    The Span class provides a lightweight, non-owning view into a contiguous sequence of elements.
+ *              It is designed to be a safer alternative to raw pointers and array references, with
+ *              bounds-checking and other safety features.
+ *
+ *  \note       Based on the Adaptive AUTOSAR SWS (e.g., R24-11) requirements for the "Span" type, especially:
+ */
+#ifndef OPEN_AA_ADAPTIVE_AUTOSAR_LIBS_INCLUDE_ARA_CORE_SPAN_H_
+#define OPEN_AA_ADAPTIVE_AUTOSAR_LIBS_INCLUDE_ARA_CORE_SPAN_H_
+
+#include <cstddef>               // For std::size_t
+#include <limits>                // For std::numeric_limits
+#include <type_traits>          // For std::remove_cv_t, std::is_same_v
+#include <iterator>             // For std::reverse_iterator
+#include <utility>              // For std::forward, std::declval
+
+
+namespace ara {
+namespace core {
+
+
+/*! \brief  The maximum size for a dynamic extent in a span.
+ *
+ * This constant represents the maximum size that can be used for a span with dynamic extent.
+ * It is set to the maximum value of std::size_t, which is typically the largest possible size
+ * for an object in memory.
+ *
+ * \note [SWS_CORE_01901] This is used to indicate that a span can have a dynamic size at runtime.
+ */
+constexpr std::size_t dynamic_extent =  std::numeric_limits<std::size_t>::max();
+
+/*! \brief  The Span class template.
+ *
+ * \tparam T The type of elements in the span.
+ * \tparam Extent The size of the span (or dynamic_extent for dynamic size).
+ *
+ * \details
+ * - This class provides a non-owning view into a contiguous sequence of elements.
+ * - It supports bounds-checking, iteration, and other utilities similar to std::span.
+ * - It is designed to be lightweight and efficient, avoiding unnecessary copies.
+ *
+ * \note [SWS_CORE_01900] This class is a core part of the Adaptive AUTOSAR platform's data handling utilities.
+ */
+template <typename T, std::size_t Extent = dynamic_extent>
+class Span {
+public:
+    using element_type = T;                                                /*!< [SWS_CORE_01911] The type of elements in the span.                        */
+    using value_type = std::remove_cv_t<element_type>;                     /*!< [SWS_CORE_01912] The type of elements in the span, without cv-qualifiers. */ 
+    using size_type = std::size_t;                                         /*!< [SWS_CORE_01921] The type used for sizes and indices.                     */
+    using difference_type = std::ptrdiff_t;                                /*!< [SWS_CORE_01914] The type used for differences between pointers.          */
+    using pointer = element_type*;                                         /*!< [SWS_CORE_01915] Pointer to the first element in the span.                */
+    using const_pointer = const element_type*;                             /*!< [SWS_CORE_01922] Pointer to the first element in a const span.            */
+    using reference = element_type&;                                       /*!< [SWS_CORE_01916] Reference to an element in the span.                     */
+    using const_reference = const element_type&;                           /*!< [SWS_CORE_01923] Reference to an element in a const span.                 */
+    using iterator = element_type*;                                        /*!< [SWS_CORE_01917] Iterator type for the span.                              */
+    using const_iterator = const element_type*;                            /*!< [SWS_CORE_01918] Const iterator type for the span.                        */
+    using reverse_iterator = std::reverse_iterator<iterator>;              /*!< [SWS_CORE_01919] Reverse iterator type for the span.                      */
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;  /*!< [SWS_CORE_01920] Const reverse iterator type for the span.                */
+
+    static constexpr size_type extent = Extent;                            /*!< [SWS_CORE_01931] The size of the span, or dynamic_extent if dynamic.      */
+
+    constexpr Span(const Span& other) noexcept = default;                  /*!< [SWS_CORE_01949] Copy constructor.                                         */
+
+
+};
+
+
+/**********************************************************************************************************************
+ *  NON-MEMBER FUNCTIONS
+ *********************************************************************************************************************/
+
+/*! \brief  Creates a span from a pointer and size.
+ *
+ * \tparam T The type of elements in the span.
+ * \param ptr Pointer to the first element of the span.
+ * \param size The number of elements in the span.
+ * \return A span object representing the range from ptr to ptr + size.
+ *
+ * \note   [SWS_CORE_01990] This function is a convenience wrapper to create a span from a pointer and a size.
+ */
+template <typename T>
+constexpr auto MakeSpan(T* ptr, typename Span<T>::size_type size) noexcept -> Span<T> {
+    return Span<T>(ptr, size);
+}
+
+
+/*! \brief  Creates a span from two pointers.
+ *
+ * \tparam T The type of elements in the span.
+ * \param firstElem Pointer to the first element of the span.
+ * \param lastElem Pointer to one past the last element of the span.
+ * \return A span object representing the range from firstElem to lastElem.
+ *
+ * \note   [SWS_CORE_01991] This function is a convenience wrapper to create a span from two pointers.
+ */
+template <typename T>
+constexpr auto MakeSpan(T* firstElem, T* lastElem) noexcept -> Span<T> {
+    return Span<T>(firstElem, lastElem - firstElem);
+}
+
+/*! \brief  Creates a span from an array.
+ *
+ * \tparam T The type of elements in the array.
+ * \param arr Reference to the array.
+ * \return A span object representing the range of the array.
+ *
+ * \note   [SWS_CORE_01992] This function is a convenience wrapper to create a span from an array.
+ */
+template <typename T, std::size_t N>
+constexpr auto MakeSpan(T(&arr)[N]) noexcept -> Span<T> {
+    return Span<T>(arr, N);
+}
+
+/*! \brief  Creates a span from a container.
+ *
+ * \tparam Container The type of the container (e.g., std::vector, std::array).
+ * \param cont Reference to the container.
+ * \return A span object representing the range of the container.
+ *
+ * \note   [SWS_CORE_01993] This function is a convenience wrapper to create a span from a container.
+ */
+template <typename Container>
+constexpr auto MakeSpan(Container& cont) noexcept -> Span<typename Container::value_type> {
+    return Span<typename Container::value_type>(cont.data(), cont.size());
+}
+
+/*! \brief  Creates a const span from a container.
+ *
+ * \tparam Container The type of the container (e.g., std::vector, std::array).
+ * \param cont Reference to the container.
+ * \return A const span object representing the range of the container.
+ *
+ * \note   [SWS_CORE_01994] This function is a convenience wrapper to create a const span from a container.
+ */
+template <typename Container>
+constexpr auto MakeSpan(const Container& cont) noexcept -> Span<typename Container::value_type const> {
+    return Span<typename Container::value_type const>(cont.data(), cont.size());
+}
+
+/*! \brief  Converts a span of elements to a span of bytes.
+ *
+ * \tparam ElementType The type of elements in the span.
+ * \tparam Extent The size of the span (or dynamic_extent for dynamic size).
+ * \param s The span to convert.
+ * \return A span of bytes representing the same data as the original span.
+ *
+ * \note   [SWS_CORE_01980] This function is used to reinterpret the data in a span as bytes.
+ */
+template <typename ElementType, std::size Extent>
+auto as_bytes(Span<ElementType, Extent> s) noexcept -> Span<const Byte, Extent==dynamic_extent? dynamic_extent : Extent * sizeof(ElementType)> {
+    return Span<const Byte, Extent==dynamic_extent? dynamic_extent : Extent * sizeof(ElementType)>(reinterpret_cast<const Byte*>(s.data()), s.size_bytes());
+}
+
+/*! \brief  Converts a span of elements to a writable span of bytes.
+ *
+ * \tparam ElementType The type of elements in the span.
+ * \tparam Extent The size of the span (or dynamic_extent for dynamic size).
+ * \param s The span to convert.
+ * \return A writable span of bytes representing the same data as the original span.
+ *
+ * \note   [SWS_CORE_01981] This function is used to reinterpret the data in a span as writable bytes.
+ */
+template <typename ElementType, std::size Extent>
+auto as_writable_bytes(Span<ElementType, Extent> s) noexcept -> Span<Byte, Extent==dynamic_extent? dynamic_extent : Extent * sizeof(ElementType)> {
+    return Span<Byte, Extent==dynamic_extent? dynamic_extent : Extent * sizeof(ElementType)>(reinterpret_cast<Byte*>(s.data()), s.size_bytes());
+}
+
+} // namespace core
+} // namespace ara
+
+#endif // OPEN_AA_ADAPTIVE_AUTOSAR_LIBS_INCLUDE_ARA_CORE_SPAN_H_

--- a/components/open-aa-std-adaptive-autosar-libs/src/ara/core/internal/violation_handler.cpp
+++ b/components/open-aa-std-adaptive-autosar-libs/src/ara/core/internal/violation_handler.cpp
@@ -124,6 +124,33 @@ auto ViolationHandler::Instance() noexcept -> ViolationHandler&
     );
 }
 
+[[noreturn]] auto ViolationHandler::TriggerByteRangeViolation(ByteKey&& /*unused*/,
+                                                    std::string_view location,
+                                                    long long value) noexcept -> void
+{
+    // Allocate a buffer for the numeric value.
+    char valueBuffer[32]{0};
+
+    // Convert the value to characters using std::to_chars.
+    auto [valuePtr, ec] = std::to_chars(valueBuffer, valueBuffer + sizeof(valueBuffer), value);
+
+    // Create a string_view from the conversion result.
+    std::string_view valueStr = (ec == std::errc{}) 
+                                ? std::string_view(valueBuffer, static_cast<std::size_t>(valuePtr - valueBuffer)) 
+                                : "";
+
+    // Terminate the process by calling the Abort API.
+    ara::core::Abort(
+        "[App vlt][FATAL]: Violation detected in ",
+        GetProcessIdentifier(),
+        " Byte range violation at ",
+        location,
+        ": Byte range violation: Invalid byte value ",
+        valueStr,
+        "."
+    );
+}
+
 
 
 /**********************************************************************************************************************

--- a/open-aa-tests/core_platform/CMakeLists.txt
+++ b/open-aa-tests/core_platform/CMakeLists.txt
@@ -15,3 +15,5 @@
 add_subdirectory(core_array_test)
 
 add_subdirectory(core_abort_test)
+
+add_subdirectory(core_byte_test)

--- a/open-aa-tests/core_platform/core_array_test/ara_core_array.cpp
+++ b/open-aa-tests/core_platform/core_array_test/ara_core_array.cpp
@@ -313,7 +313,7 @@ void TestGetFunction()
 {
     std::cout << "\n=== Test 2: get<I>() Functionality ===\n";
     
-    #ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+    #ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
         // Conditional Safe Mode: Use types that may throw
         ara::core::Array<std::string,3> strArr = {"Alpha", "Beta", "Gamma"};
 
@@ -577,7 +577,7 @@ void TestWithUserDefinedStruct()
                   << structArr[i].id << ", Score=" << structArr[i].score << ")\n";
     }
 
-    #ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+    #ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
         // Conditional Safe Mode: Additional tests with std::string
         std::cout << "\n=== Additional Test: Usage with std::string in Conditional Safe Mode ===\n";
         ara::core::Array<std::string,3> strArr = {"Alpha", "Beta", "Gamma"};
@@ -1181,7 +1181,7 @@ void TestTwoDimensionalArrays()
         std::cout << "\n";
     }
 
-    #ifdef ARA_CORE_ARRAY_ENABLE_CONDITIONAL_EXCEPTIONS
+    #ifdef ENABLE_PLATFORM_CONDITIONAL_EXCEPTION
         // Conditional Safe Mode: Additional tests with two-dimensional arrays involving std::string
         std::cout << "\n=== Additional Test: Two-Dimensional Arrays with std::string ===\n";
         ara::core::Array<ara::core::Array<std::string,2>, 2> strMatrix = {

--- a/open-aa-tests/core_platform/core_array_test/ara_core_array.cpp
+++ b/open-aa-tests/core_platform/core_array_test/ara_core_array.cpp
@@ -1267,31 +1267,35 @@ void TestTupleInterface()
     }
 
     /*---------------------------------------------------*
-     * 6. std::apply                                     *
+     * 6. variadic-sum with ara::core::apply              *
      *---------------------------------------------------*/
-    // {
-    //     // sum all elements at compile time
-    //     constexpr int sum = std::apply(
-    //         [](int x, int y, int z){ return x + y + z; },
-    //         ca
-    //     );
-    //     static_assert(sum == 6, "std::apply sum failed");
-    // }
-
+    {
+        /*  generic lambda: accepts any number of arguments,
+            returns their sum with a fold-expression        */
+        constexpr int sum = ara::core::apply(
+            [](auto... xs) constexpr { return (xs + ...); },
+            ca
+        );
+        static_assert(sum == 6, "variadic sum failed");
+    }
+    
     /*---------------------------------------------------*
-     * 7. std::tuple_cat                                 *
+     * 7. ara::core::tuple_cat                            *
      *---------------------------------------------------*/
-    // {
-    //     using A2 = ara::core::Array<int,2>;
-    //     constexpr A2 cb{ 4, 5 };
-    //     // concatenate two Arrays into a single tuple
-    //     constexpr auto tup = std::tuple_cat(ca, cb);
-    //     static_assert( std::tuple_size_v<decltype(tup)> == 5, "tuple_cat size wrong" );
-    //     // verify individual elements
-    //     assert( std::get<0>(tup) == 1 );
-    //     assert( std::get<3>(tup) == 4 );
-    //     assert( std::get<4>(tup) == 5 );
-    // }
+    {
+        using A2 = ara::core::Array<int,2>;
+        constexpr A2 cb{ 4, 5 };
+    
+        /* concatenate two Arrays into a single tuple */
+        constexpr auto tup = ara::core::tuple_cat(ca, cb);
+        static_assert( std::tuple_size_v<decltype(tup)> == 5,
+                       "tuple_cat size wrong" );
+    
+        /* verify individual elements */
+        static_assert( std::get<0>(tup) == 1 );
+        static_assert( std::get<3>(tup) == 4 );
+        static_assert( std::get<4>(tup) == 5 );
+    }
 
     std::cout << "\n>>> Tuple interface - ALL CHECKS PASSED\n";
 }

--- a/open-aa-tests/core_platform/core_byte_test/CMakeLists.txt
+++ b/open-aa-tests/core_platform/core_byte_test/CMakeLists.txt
@@ -1,0 +1,43 @@
+#[=======================================================================[
+Author: Sherif Mohamed
+
+File description:
+-----------------
+CMake configuration for the core_platform tests.
+#]=======================================================================]
+
+#****************************************************************************************************
+# Test Executable Definition
+#****************************************************************************************************
+add_executable(core_byte_test
+    ara_core_byte.cpp
+)
+
+# If you want a compile definition, do so for the test, not the core lib:
+target_compile_definitions(core_byte_test
+    PRIVATE
+        PROCESS_IDENTIFIER="TestByte"
+)
+
+#****************************************************************************************************
+# Linking Configuration
+#****************************************************************************************************
+target_link_libraries(core_byte_test
+    PRIVATE
+        ara::core::byte
+)
+
+#****************************************************************************************************
+# Installation Configuration
+#****************************************************************************************************
+install(TARGETS core_byte_test
+    DESTINATION platform_core_test/core_byte_test/bin
+)
+
+#****************************************************************************************************
+# Testing Configuration
+#****************************************************************************************************
+enable_testing()
+add_test(NAME AraCoreByteTest
+    COMMAND ara_core_byte_test
+)

--- a/open-aa-tests/core_platform/core_byte_test/ara_core_byte.cpp
+++ b/open-aa-tests/core_platform/core_byte_test/ara_core_byte.cpp
@@ -1,0 +1,1611 @@
+/**********************************************************************************************************************
+ *  PROJECT
+ *  -------------------------------------------------------------------------------------------------------------------
+ *  \verbatim
+ *  OpenAA: Open Source Adaptive AUTOSAR Project (CXX_STANDARD 17)
+ *  \endverbatim
+ *  -------------------------------------------------------------------------------------------------------------------
+ *  FILE DESCRIPTION
+ *  -------------------------------------------------------------------------------------------------------------------
+ *  \file       ara_core_byte_test.cpp
+ *  \brief      Comprehensive test application for the ara::core::Byte type.
+ *
+ *  \details    This file contains multiple test functions covering all aspects of ara::core::Byte:
+ *              1.  Basic Construction and Conversion
+ *              2.  Explicit Conversions and Type Safety
+ *              3.  Bitwise Operations (AND, OR, XOR, NOT)
+ *              4.  Shift Operations (Left and Right)
+ *              5.  Comparison Operations
+ *              6.  Bit Manipulation Methods (test, set, reset, flip)
+ *              7.  Utility Functions (to_byte, to_integer)
+ *              8.  User-Defined Literals
+ *              9.  Const Correctness
+ *              10. Zero and Max Value Edge Cases
+ *              11. Type Traits Verification
+ *              12. Performance Comparisons
+ *              13. Violation Scenarios (separate functions)
+ *              14. Negative Compilation Scenarios (commented out)
+ *
+ *  \note       All tests run sequentially with clear output. Violation tests are in separate
+ *              functions that can be called individually to observe termination behavior.
+ *********************************************************************************************************************/
+
+#if defined(__linux__)
+#include <sys/prctl.h>
+#elif defined(__QNXNTO__)
+#include <pthread.h>
+#endif
+#include "ara/core/byte.h"         // The ara::core::Byte implementation
+#include <iostream>                 // For std::cout
+#include <cassert>                  // For runtime checks
+#include <chrono>                   // For performance measurements
+#include <cstring>                  // For memcpy comparisons
+#include <type_traits>              // For type trait checks
+#include <limits>                   // For numeric_limits tests
+#include <array>                    // For std containers comparison
+#include <iomanip>                  // For output formatting
+#include <string>                   // For std::string
+#include <string_view>              // For std::string_view
+
+static constexpr std::string_view   kProcessNameView{"CoreByteTest"};
+static constexpr std::uint8_t       kMaxProcessName{15};
+
+/**********************************************************************************************************************
+ *  UTILITY FUNCTIONS
+ *********************************************************************************************************************/
+
+/*!
+ * \brief Simple performance timer using std::chrono
+ */
+class PerfTimer {
+    using Clock = std::chrono::high_resolution_clock;
+    using TimePoint = Clock::time_point;
+    using Duration = std::chrono::duration<double, std::micro>;
+
+    TimePoint start_;
+public:
+    PerfTimer() : start_(Clock::now()) {}
+    
+    [[nodiscard]] auto elapsed() const -> double {
+        return Duration(Clock::now() - start_).count();
+    }
+    
+    void reset() { start_ = Clock::now(); }
+};
+
+/*!
+ * \brief Print test section header
+ */
+void PrintTestHeader(const std::string& testName) {
+    std::cout << "\n" << std::string(60, '=') << "\n";
+    std::cout << "Test: " << testName << "\n";
+    std::cout << std::string(60, '=') << "\n";
+}
+
+/*!
+ * \brief Print sub-test header
+ */
+void PrintSubTest(const std::string& subTestName) {
+    std::cout << "\n--- " << subTestName << " ---\n";
+}
+
+/**********************************************************************************************************************
+ *  FORWARD DECLARATIONS
+ *********************************************************************************************************************/
+void TestBasicConstructionAndConversion();
+void TestExplicitConversionsAndTypeSafety();
+void TestBitwiseOperations();
+void TestShiftOperations();
+void TestComparisonOperations();
+void TestBitManipulationMethods();
+void TestUtilityFunctions();
+void TestUserDefinedLiterals();
+void TestConstCorrectness();
+void TestEdgeCases();
+void TestTypeTraits();
+void TestPerformanceComparisons();
+
+// Violation tests (will terminate the program)
+void TestByteRangeViolation();
+void TestBitPositionViolation();
+void TestShiftAmountViolation();
+
+// Negative compilation tests (commented out)
+void TestNegativeCompilationScenarios();
+
+/**********************************************************************************************************************
+ *  MAIN FUNCTION
+ *********************************************************************************************************************/
+int main(int argc, char* argv[])
+{
+    static_assert(kProcessNameView.size() <= kMaxProcessName,
+        "\n[ERROR] Process name is too long!!\n");
+
+    #if defined(__linux__)
+        prctl(PR_SET_NAME, kProcessNameView.data(), 0, 0, 0);
+    #elif defined(__QNXNTO__)
+        pthread_setname_np(pthread_self(), kProcessNameView.data());
+    #endif
+
+    std::cout << "\n╔════════════════════════════════════════════════════════════╗\n";
+    std::cout << "║         ara::core::Byte Comprehensive Test Suite           ║\n";
+    std::cout << "╚════════════════════════════════════════════════════════════╝\n";
+
+    // Check if user wants to run violation tests
+    if (argc > 1) {
+        std::string arg = argv[1];
+        if (arg == "violation-range") {
+            std::cout << "\nRunning Byte Range Violation Test (will terminate)...\n";
+            TestByteRangeViolation();
+            return 1; // Should never reach here
+        }
+        else if (arg == "violation-bit") {
+            std::cout << "\nRunning Bit Position Violation Test (will terminate)...\n";
+            TestBitPositionViolation();
+            return 1; // Should never reach here
+        }
+        else if (arg == "violation-shift") {
+            std::cout << "\nRunning Shift Amount Violation Test (will terminate)...\n";
+            TestShiftAmountViolation();
+            return 1; // Should never reach here
+        }
+        else {
+            std::cout << "\nUsage: " << argv[0] << " [violation-range|violation-bit|violation-shift]\n";
+            std::cout << "       No arguments: Run all non-terminating tests\n";
+            std::cout << "       violation-range: Test byte range violation\n";
+            std::cout << "       violation-bit: Test bit position violation\n";
+            std::cout << "       violation-shift: Test shift amount violation\n\n";
+        }
+    }
+
+    // Run all non-terminating tests sequentially
+    TestBasicConstructionAndConversion();
+    TestExplicitConversionsAndTypeSafety();
+    TestBitwiseOperations();
+    TestShiftOperations();
+    TestComparisonOperations();
+    TestBitManipulationMethods();
+    TestUtilityFunctions();
+    TestUserDefinedLiterals();
+    TestConstCorrectness();
+    TestEdgeCases();
+    TestTypeTraits();
+    TestPerformanceComparisons();
+    TestNegativeCompilationScenarios(); // All scenarios are commented out
+
+    std::cout << "\n╔════════════════════════════════════════════════════════════╗\n";
+    std::cout << "║              ALL TESTS PASSED SUCCESSFULLY!                ║\n";
+    std::cout << "╚════════════════════════════════════════════════════════════╝\n\n";
+
+    return 0;
+}
+
+/**********************************************************************************************************************
+ *  TEST IMPLEMENTATIONS
+ *********************************************************************************************************************/
+
+/*!
+ * \brief Test #1: Basic Construction and Conversion
+ */
+void TestBasicConstructionAndConversion()
+{
+    PrintTestHeader("Basic Construction and Conversion");
+
+    PrintSubTest("Default Construction");
+    {
+        ara::core::Byte b1;  // Uninitialized
+        ara::core::Byte b2{}; // Zero-initialized
+        
+        // Note: b1 has indeterminate value, b2 is zero
+        std::cout << "Default constructed (b2): " << static_cast<int>(b2.to_integer()) << " (expected 0)\n";
+        assert(b2.to_integer() == 0);
+        
+        // Use b1 to avoid warning
+        static_cast<void>(b1);
+    }
+
+    PrintSubTest("Construction from Integral Types");
+    {
+        // Unsigned types
+        ara::core::Byte b_uint8{static_cast<std::uint8_t>(42)};
+        ara::core::Byte b_uint16{static_cast<std::uint16_t>(100)};
+        ara::core::Byte b_uint32{static_cast<std::uint32_t>(255)};
+        
+        std::cout << "From uint8_t(42): " << static_cast<int>(b_uint8.to_integer()) << "\n";
+        std::cout << "From uint16_t(100): " << static_cast<int>(b_uint16.to_integer()) << "\n";
+        std::cout << "From uint32_t(255): " << static_cast<int>(b_uint32.to_integer()) << "\n";
+        
+        assert(b_uint8.to_integer() == 42);
+        assert(b_uint16.to_integer() == 100);
+        assert(b_uint32.to_integer() == 255);
+        
+        // Signed types
+        [[maybe_unused]] ara::core::Byte b_int8{static_cast<std::int8_t>(127)};
+        [[maybe_unused]] ara::core::Byte b_int16{static_cast<std::int16_t>(200)};
+        [[maybe_unused]] ara::core::Byte b_int32{200};
+        
+        assert(b_int8.to_integer() == 127);
+        assert(b_int16.to_integer() == 200);
+        assert(b_int32.to_integer() == 200);
+    }
+
+    PrintSubTest("Copy and Move Semantics");
+    {
+        ara::core::Byte original{42};
+        
+        // Copy construction
+        ara::core::Byte copied{original};
+        std::cout << "Copy constructed: " << static_cast<int>(copied.to_integer()) << " (expected 42)\n";
+        assert(copied.to_integer() == 42);
+        assert(original.to_integer() == 42); // Original unchanged
+        
+        // Move construction
+        ara::core::Byte moved{std::move(original)};
+        std::cout << "Move constructed: " << static_cast<int>(moved.to_integer()) << " (expected 42)\n";
+        assert(moved.to_integer() == 42);
+        // Note: original is trivially copyable, so move is same as copy
+        
+        // Copy assignment
+        ara::core::Byte copy_assigned;
+        copy_assigned = copied;
+        assert(copy_assigned.to_integer() == 42);
+        
+        // Move assignment
+        ara::core::Byte move_assigned;
+        move_assigned = std::move(copied);
+        assert(move_assigned.to_integer() == 42);
+    }
+
+    PrintSubTest("Compile-time Construction");
+    {
+        constexpr ara::core::Byte cb1{0};
+        constexpr ara::core::Byte cb2{128};
+        constexpr ara::core::Byte cb3{255};
+        
+        static_assert(cb1.to_integer() == 0, "Constexpr construction failed");
+        static_assert(cb2.to_integer() == 128, "Constexpr construction failed");
+        static_assert(cb3.to_integer() == 255, "Constexpr construction failed");
+        
+        std::cout << "Compile-time construction verified\n";
+    }
+}
+
+/*!
+ * \brief Test #2: Explicit Conversions and Type Safety
+ */
+void TestExplicitConversionsAndTypeSafety()
+{
+    PrintTestHeader("Explicit Conversions and Type Safety");
+
+    PrintSubTest("Explicit Conversion to Integral Types");
+    {
+        ara::core::Byte b{200};
+        
+        // Explicit conversion using cast operator
+        auto as_uint8 = static_cast<std::uint8_t>(b);
+        auto as_uint16 = static_cast<std::uint16_t>(b);
+        auto as_int = static_cast<int>(b);
+        
+        std::cout << "Byte{200} as uint8_t: " << static_cast<int>(as_uint8) << "\n";
+        std::cout << "Byte{200} as uint16_t: " << as_uint16 << "\n";
+        std::cout << "Byte{200} as int: " << as_int << "\n";
+        
+        assert(as_uint8 == 200);
+        assert(as_uint16 == 200);
+        assert(as_int == 200);
+        
+        // Using to_integer<T>()
+        auto to_int8 = b.to_integer<std::int8_t>();
+        auto to_uint32 = b.to_integer<std::uint32_t>();
+        
+        std::cout << "to_integer<int8_t>(): " << static_cast<int>(to_int8) << " (note: overflow)\n";
+        std::cout << "to_integer<uint32_t>(): " << to_uint32 << "\n";
+        
+        assert(to_int8 == static_cast<std::int8_t>(200)); // -56 due to overflow
+        assert(to_uint32 == 200);
+    }
+
+    PrintSubTest("No Implicit Conversions");
+    {
+        ara::core::Byte b{42};
+        
+        // These would fail to compile (verified in negative tests):
+        // int x = b;           // Error: no implicit conversion to int
+        // bool flag = b;       // Error: no implicit conversion to bool
+        // if (b) {}           // Error: no implicit conversion to bool
+        
+        // Correct usage requires explicit conversion:
+        int x = static_cast<int>(b);
+        bool flag = (b.to_integer() != 0);
+        
+        std::cout << "Explicit int conversion: " << x << "\n";
+        std::cout << "Explicit bool check: " << (flag ? "true" : "false") << "\n";
+        
+        assert(x == 42);
+        assert(flag == true);
+    }
+
+    PrintSubTest("Type Safety with Different Types");
+    {
+        // These demonstrate that Byte maintains type safety
+        ara::core::Byte b1{100};
+        ara::core::Byte b2{200};
+        
+        // Cannot accidentally mix with integers in operations
+        // int sum = b1 + 50;  // Would fail to compile
+        
+        // Correct usage:
+        int sum = static_cast<int>(b1.to_integer()) + 50;
+        std::cout << "Byte{100}.to_integer() + 50 = " << sum << "\n";
+        assert(sum == 150);
+        
+        // Byte operations return Byte
+        ara::core::Byte b_result = b1 | b2;
+        std::cout << "Byte{100} | Byte{200} = " << static_cast<int>(b_result.to_integer()) << "\n";
+        assert(b_result.to_integer() == (100 | 200));
+    }
+}
+
+/*!
+ * \brief Test #3: Bitwise Operations
+ */
+void TestBitwiseOperations()
+{
+    PrintTestHeader("Bitwise Operations");
+
+    PrintSubTest("Bitwise AND");
+    {
+        ara::core::Byte a{0b11110000};
+        ara::core::Byte b{0b10101010};
+        
+        ara::core::Byte result = a & b;
+        std::cout << "0b11110000 & 0b10101010 = 0b" 
+                  << std::bitset<8>(result.to_integer()) << " (0b10100000 expected)\n";
+        assert(result.to_integer() == 0b10100000);
+        
+        // Compound assignment
+        a &= b;
+        assert(a.to_integer() == 0b10100000);
+        
+        // Identity: x & 0xFF = x
+        [[maybe_unused]] ara::core::Byte x{123};
+        assert((x & ara::core::Byte{0xFF}).to_integer() == 123);
+        
+        // Zero: x & 0 = 0
+        assert((x & ara::core::Byte{0}).to_integer() == 0);
+    }
+
+    PrintSubTest("Bitwise OR");
+    {
+        ara::core::Byte a{0b11110000};
+        ara::core::Byte b{0b10101010};
+        
+        ara::core::Byte result = a | b;
+        std::cout << "0b11110000 | 0b10101010 = 0b" 
+                  << std::bitset<8>(result.to_integer()) << " (0b11111010 expected)\n";
+        assert(result.to_integer() == 0b11111010);
+        
+        // Compound assignment
+        a |= b;
+        assert(a.to_integer() == 0b11111010);
+        
+        // Identity: x | 0 = x
+        [[maybe_unused]] ara::core::Byte x{123};
+        assert((x | ara::core::Byte{0}).to_integer() == 123);
+        
+        // All ones: x | 0xFF = 0xFF
+        assert((x | ara::core::Byte{0xFF}).to_integer() == 0xFF);
+    }
+
+    PrintSubTest("Bitwise XOR");
+    {
+        ara::core::Byte a{0b11110000};
+        ara::core::Byte b{0b10101010};
+        
+        ara::core::Byte result = a ^ b;
+        std::cout << "0b11110000 ^ 0b10101010 = 0b" 
+                  << std::bitset<8>(result.to_integer()) << " (0b01011010 expected)\n";
+        assert(result.to_integer() == 0b01011010);
+        
+        // Compound assignment
+        a ^= b;
+        assert(a.to_integer() == 0b01011010);
+        
+        // Self-cancel: x ^ x = 0
+        [[maybe_unused]] ara::core::Byte x{123};
+        assert((x ^ x).to_integer() == 0);
+        
+        // Identity: x ^ 0 = x
+        assert((x ^ ara::core::Byte{0}).to_integer() == 123);
+    }
+
+    PrintSubTest("Bitwise NOT");
+    {
+        ara::core::Byte a{0b11110000};
+        ara::core::Byte result = ~a;
+        
+        std::cout << "~0b11110000 = 0b" 
+                  << std::bitset<8>(result.to_integer()) << " (0b00001111 expected)\n";
+        assert(result.to_integer() == 0b00001111);
+        
+        // Double negation: ~~x = x
+        [[maybe_unused]] ara::core::Byte x{123};
+        assert((~~x).to_integer() == 123);
+        
+        // NOT of 0 = 0xFF
+        assert((~ara::core::Byte{0}).to_integer() == 0xFF);
+        
+        // NOT of 0xFF = 0
+        assert((~ara::core::Byte{0xFF}).to_integer() == 0);
+    }
+
+    PrintSubTest("Constexpr Bitwise Operations");
+    {
+        constexpr ara::core::Byte a{0xF0};
+        constexpr ara::core::Byte b{0xAA};
+        
+        constexpr ara::core::Byte c_and = a & b;
+        constexpr ara::core::Byte c_or = a | b;
+        constexpr ara::core::Byte c_xor = a ^ b;
+        constexpr ara::core::Byte c_not = ~a;
+        
+        static_assert(c_and.to_integer() == 0xA0, "Constexpr AND failed");
+        static_assert(c_or.to_integer() == 0xFA, "Constexpr OR failed");
+        static_assert(c_xor.to_integer() == 0x5A, "Constexpr XOR failed");
+        static_assert(c_not.to_integer() == 0x0F, "Constexpr NOT failed");
+        
+        std::cout << "Compile-time bitwise operations verified\n";
+    }
+}
+
+/*!
+ * \brief Test #4: Shift Operations
+ */
+void TestShiftOperations()
+{
+    PrintTestHeader("Shift Operations");
+
+    PrintSubTest("Left Shift");
+    {
+        ara::core::Byte b{0b00110011};
+        
+        // Shift by various amounts
+        for (int shift = 0; shift <= 7; ++shift) {
+            ara::core::Byte result = b << shift;
+            std::cout << "0b00110011 << " << shift << " = 0b" 
+                      << std::bitset<8>(result.to_integer()) << "\n";
+            assert(result.to_integer() == static_cast<std::uint8_t>((0b00110011u << static_cast<unsigned>(shift)) & 0xFFu));
+        }
+        
+        // Compound assignment
+        ara::core::Byte b2{0b00000001};
+        b2 <<= 7;
+        assert(b2.to_integer() == 0b10000000);
+        
+        // Edge case: shift by 0
+        [[maybe_unused]] ara::core::Byte b3{123};
+        assert((b3 << 0).to_integer() == 123);
+    }
+
+    PrintSubTest("Right Shift");
+    {
+        ara::core::Byte b{0b11001100};
+        
+        // Shift by various amounts
+        for (int shift = 0; shift <= 7; ++shift) {
+            ara::core::Byte result = b >> shift;
+            std::cout << "0b11001100 >> " << shift << " = 0b" 
+                      << std::bitset<8>(result.to_integer()) << "\n";
+            assert(result.to_integer() == static_cast<std::uint8_t>(0b11001100u >> static_cast<unsigned>(shift)));
+        }
+        
+        // Compound assignment
+        ara::core::Byte b2{0b10000000};
+        b2 >>= 7;
+        assert(b2.to_integer() == 0b00000001);
+        
+        // Edge case: shift by 0
+        [[maybe_unused]] ara::core::Byte b3{123};
+        assert((b3 >> 0).to_integer() == 123);
+    }
+
+    PrintSubTest("Shift Amount Masking");
+    {
+        // Shift amounts are masked to [0, 7]
+        ara::core::Byte b{0b00000001};
+        
+        // These are masked internally
+        ara::core::Byte r1 = b << 8;  // 8 & 0x7 = 0
+        ara::core::Byte r2 = b << 9;  // 9 & 0x7 = 1
+        
+        std::cout << "Shift by 8 (masked to 0): " << static_cast<int>(r1.to_integer()) << "\n";
+        std::cout << "Shift by 9 (masked to 1): " << static_cast<int>(r2.to_integer()) << "\n";
+        
+        assert(r1.to_integer() == 0b00000001);  // No shift
+        assert(r2.to_integer() == 0b00000010);  // Shifted by 1
+    }
+
+    PrintSubTest("Constexpr Shift Operations");
+    {
+        constexpr ara::core::Byte b{0x0F};
+        
+        constexpr ara::core::Byte left2 = b << 2;
+        constexpr ara::core::Byte left4 = b << 4;
+        constexpr ara::core::Byte right2 = b >> 2;
+        constexpr ara::core::Byte right4 = b >> 4;
+        
+        static_assert(left2.to_integer() == 0x3C, "Constexpr left shift failed");
+        static_assert(left4.to_integer() == 0xF0, "Constexpr left shift failed");
+        static_assert(right2.to_integer() == 0x03, "Constexpr right shift failed");
+        static_assert(right4.to_integer() == 0x00, "Constexpr right shift failed");
+        
+        std::cout << "Compile-time shift operations verified\n";
+    }
+}
+
+/*!
+ * \brief Test #5: Comparison Operations
+ */
+void TestComparisonOperations()
+{
+    PrintTestHeader("Comparison Operations");
+
+    PrintSubTest("Equality Comparisons");
+    {
+        ara::core::Byte a{42};
+        ara::core::Byte b{42};
+        ara::core::Byte c{100};
+        
+        std::cout << "Byte{42} == Byte{42}: " << (a == b ? "true" : "false") << " (expected true)\n";
+        std::cout << "Byte{42} != Byte{100}: " << (a != c ? "true" : "false") << " (expected true)\n";
+        
+        assert(a == b);
+        assert(!(a != b));
+        assert(a != c);
+        assert(!(a == c));
+        
+        // Self-comparison
+        assert(a == a);
+        assert(!(a != a));
+    }
+
+    PrintSubTest("Relational Comparisons");
+    {
+        [[maybe_unused]] ara::core::Byte small{10};
+        [[maybe_unused]] ara::core::Byte medium{100};
+        [[maybe_unused]] ara::core::Byte large{200};
+        
+        // Less than
+        assert(small < medium);
+        assert(medium < large);
+        assert(!(large < small));
+        assert(!(medium < medium));
+        
+        // Less than or equal
+        assert(small <= medium);
+        assert(medium <= medium);
+        assert(!(large <= small));
+        
+        // Greater than
+        assert(large > medium);
+        assert(medium > small);
+        assert(!(small > large));
+        assert(!(medium > medium));
+        
+        // Greater than or equal
+        assert(large >= medium);
+        assert(medium >= medium);
+        assert(!(small >= large));
+        
+        std::cout << "All relational comparisons passed\n";
+    }
+
+    PrintSubTest("Edge Case Comparisons");
+    {
+        [[maybe_unused]] ara::core::Byte zero{0};
+        [[maybe_unused]] ara::core::Byte max{255};
+        
+        assert(zero < max);
+        assert(zero <= max);
+        assert(max > zero);
+        assert(max >= zero);
+        assert(zero != max);
+        assert(!(zero == max));
+        
+        // Boundary comparisons
+        [[maybe_unused]] ara::core::Byte one{1};
+        [[maybe_unused]] ara::core::Byte max_minus_one{254};
+
+        assert(zero < one);
+        assert(max_minus_one < max);
+        assert(!(max < max_minus_one));
+        
+        std::cout << "Edge case comparisons passed\n";
+    }
+
+    PrintSubTest("Constexpr Comparisons");
+    {
+        constexpr ara::core::Byte a{50};
+        constexpr ara::core::Byte b{100};
+        constexpr ara::core::Byte c{50};
+        
+        static_assert(a == c, "Constexpr equality failed");
+        static_assert(a != b, "Constexpr inequality failed");
+        static_assert(a < b, "Constexpr less than failed");
+        static_assert(a <= b, "Constexpr less than or equal failed");
+        static_assert(b > a, "Constexpr greater than failed");
+        static_assert(b >= a, "Constexpr greater than or equal failed");
+        
+        std::cout << "Compile-time comparisons verified\n";
+    }
+}
+
+/*!
+ * \brief Test #6: Bit Manipulation Methods
+ */
+void TestBitManipulationMethods()
+{
+    PrintTestHeader("Bit Manipulation Methods");
+
+    PrintSubTest("Test Bit");
+    {
+        ara::core::Byte b{0b10101010};
+        
+        std::cout << "Testing bits in 0b10101010:\n";
+        for (std::size_t i = 0; i < 8; ++i) {
+            bool bit_set = b.test(i);
+            std::cout << "  Bit " << i << ": " << (bit_set ? "1" : "0") << "\n";
+            assert(bit_set == ((0b10101010u >> i) & 1u));
+        }
+    }
+
+    PrintSubTest("Set/Reset/Flip Individual Bits");
+    {
+        ara::core::Byte b{0};
+        
+        // Set bits
+        b.set(0).set(2).set(4).set(6);
+        std::cout << "After setting bits 0,2,4,6: 0b" << std::bitset<8>(b.to_integer()) << "\n";
+        assert(b.to_integer() == 0b01010101);
+        
+        // Reset bits
+        b.reset(2).reset(6);
+        std::cout << "After resetting bits 2,6: 0b" << std::bitset<8>(b.to_integer()) << "\n";
+        assert(b.to_integer() == 0b00010001);
+        
+        // Flip bits
+        b.flip(1).flip(3).flip(5).flip(7);
+        std::cout << "After flipping bits 1,3,5,7: 0b" << std::bitset<8>(b.to_integer()) << "\n";
+        assert(b.to_integer() == 0b10111011);
+        
+        // Chain operations
+        ara::core::Byte b2{0};
+        b2.set(7).set(0).flip(3).reset(0);
+        assert(b2.to_integer() == 0b10001000);
+    }
+
+    PrintSubTest("Set/Reset/Flip All Bits");
+    {
+        ara::core::Byte b{0b10101010};
+        
+        // Set all
+        b.set();
+        std::cout << "After set(): " << static_cast<int>(b.to_integer()) << " (expected 255)\n";
+        assert(b.to_integer() == 0xFF);
+        assert(b.all());
+        
+        // Reset all
+        b.reset();
+        std::cout << "After reset(): " << static_cast<int>(b.to_integer()) << " (expected 0)\n";
+        assert(b.to_integer() == 0);
+        assert(b.none());
+        
+        // Flip all
+        b.flip();
+        std::cout << "After flip() on 0: " << static_cast<int>(b.to_integer()) << " (expected 255)\n";
+        assert(b.to_integer() == 0xFF);
+        
+        b.flip();
+        std::cout << "After flip() on 255: " << static_cast<int>(b.to_integer()) << " (expected 0)\n";
+        assert(b.to_integer() == 0);
+    }
+
+    PrintSubTest("Count, All, Any, None");
+    {
+        struct TestCase {
+            std::uint8_t value;
+            std::size_t expected_count;
+            bool expected_all;
+            bool expected_any;
+            bool expected_none;
+        };
+        
+        TestCase cases[] = {
+            {0b00000000, 0, false, false, true},
+            {0b11111111, 8, true, true, false},
+            {0b10101010, 4, false, true, false},
+            {0b11110000, 4, false, true, false},
+            {0b00000001, 1, false, true, false},
+            {0b10000000, 1, false, true, false},
+        };
+        
+        for (const auto& tc : cases) {
+            ara::core::Byte b{tc.value};
+            std::cout << "Testing 0b" << std::bitset<8>(tc.value) << ":\n";
+            std::cout << "  count(): " << b.count() << " (expected " << tc.expected_count << ")\n";
+            std::cout << "  all(): " << b.all() << " (expected " << tc.expected_all << ")\n";
+            std::cout << "  any(): " << b.any() << " (expected " << tc.expected_any << ")\n";
+            std::cout << "  none(): " << b.none() << " (expected " << tc.expected_none << ")\n";
+            
+            assert(b.count() == tc.expected_count);
+            assert(b.all() == tc.expected_all);
+            assert(b.any() == tc.expected_any);
+            assert(b.none() == tc.expected_none);
+        }
+    }
+
+    PrintSubTest("Constexpr Bit Manipulation");
+    {
+        constexpr auto test_bit_ops = []() constexpr -> bool {
+            ara::core::Byte b{0};
+            b.set(1).set(3).set(5);
+            if (b.to_integer() != 0b00101010) return false;
+            if (!b.test(1) || !b.test(3) || !b.test(5)) return false;
+            if (b.count() != 3) return false;
+            return true;
+        };
+        
+        static_assert(test_bit_ops(), "Constexpr bit manipulation failed");
+        std::cout << "Compile-time bit manipulation verified\n";
+    }
+}
+
+/*!
+ * \brief Test #7: Utility Functions
+ */
+void TestUtilityFunctions()
+{
+    PrintTestHeader("Utility Functions");
+
+    PrintSubTest("to_byte Function");
+    {
+        // From various integral types
+        auto b1 = ara::core::to_byte(42);
+        auto b2 = ara::core::to_byte(static_cast<std::uint8_t>(100));
+        auto b3 = ara::core::to_byte(static_cast<std::int16_t>(200));
+        auto b4 = ara::core::to_byte('A');  // char overload
+        
+        std::cout << "to_byte(42): " << static_cast<int>(b1.to_integer()) << "\n";
+        std::cout << "to_byte(uint8_t{100}): " << static_cast<int>(b2.to_integer()) << "\n";
+        std::cout << "to_byte(int16_t{200}): " << static_cast<int>(b3.to_integer()) << "\n";
+        std::cout << "to_byte('A'): " << static_cast<int>(b4.to_integer()) << " (ASCII 65)\n";
+        
+        assert(b1.to_integer() == 42);
+        assert(b2.to_integer() == 100);
+        assert(b3.to_integer() == 200);
+        assert(b4.to_integer() == 65);
+        
+        // Constexpr usage
+        constexpr auto cb = ara::core::to_byte(123);
+        static_assert(cb.to_integer() == 123, "Constexpr to_byte failed");
+    }
+
+    PrintSubTest("to_integer Method");
+    {
+        ara::core::Byte b{200};
+        
+        // Default (returns uint8_t)
+        auto u8 = b.to_integer();
+        std::cout << "to_integer() default: " << static_cast<int>(u8) << " (uint8_t)\n";
+        assert(u8 == 200);
+        
+        // Template versions
+        auto i8 = b.to_integer<std::int8_t>();
+        auto u16 = b.to_integer<std::uint16_t>();
+        auto i32 = b.to_integer<std::int32_t>();
+        auto u64 = b.to_integer<std::uint64_t>();
+        
+        std::cout << "to_integer<int8_t>(): " << static_cast<int>(i8) << " (overflow to -56)\n";
+        std::cout << "to_integer<uint16_t>(): " << u16 << "\n";
+        std::cout << "to_integer<int32_t>(): " << i32 << "\n";
+        std::cout << "to_integer<uint64_t>(): " << u64 << "\n";
+        
+        assert(i8 == static_cast<std::int8_t>(200));  // -56 due to overflow
+        assert(u16 == 200);
+        assert(i32 == 200);
+        assert(u64 == 200);
+    }
+
+    PrintSubTest("Round-trip Conversions");
+    {
+        // Test round-trip for all possible byte values
+        [[maybe_unused]] bool all_passed = true;
+        for (int i = 0; i <= 255; ++i) {
+            auto b = ara::core::to_byte(i);
+            auto back = static_cast<int>(b.to_integer());
+            if (back != i) {
+                all_passed = false;
+                std::cout << "Round-trip failed for " << i << "\n";
+            }
+        }
+        assert(all_passed);
+        std::cout << "All 256 round-trip conversions passed\n";
+    }
+}
+
+/*!
+ * \brief Test #8: User-Defined Literals
+ */
+void TestUserDefinedLiterals()
+{
+    PrintTestHeader("User-Defined Literals");
+
+    using namespace ara::core::literals::byte_literals;
+
+    PrintSubTest("Decimal Literals");
+    {
+        constexpr auto b0 = 0_byte;
+        constexpr auto b42 = 42_byte;
+        constexpr auto b255 = 255_byte;
+        
+        std::cout << "0_byte: " << static_cast<int>(b0.to_integer()) << "\n";
+        std::cout << "42_byte: " << static_cast<int>(b42.to_integer()) << "\n";
+        std::cout << "255_byte: " << static_cast<int>(b255.to_integer()) << "\n";
+        
+        static_assert(b0.to_integer() == 0, "Decimal literal failed");
+        static_assert(b42.to_integer() == 42, "Decimal literal failed");
+        static_assert(b255.to_integer() == 255, "Decimal literal failed");
+    }
+
+    PrintSubTest("Hexadecimal Literals");
+    {
+        constexpr auto b1 = 0x00_byte;
+        constexpr auto b2 = 0xFF_byte;
+        constexpr auto b3 = 0xAB_byte;
+        constexpr auto b4 = 0x7f_byte;
+        
+        std::cout << "0x00_byte: " << static_cast<int>(b1.to_integer()) << "\n";
+        std::cout << "0xFF_byte: " << static_cast<int>(b2.to_integer()) << "\n";
+        std::cout << "0xAB_byte: " << static_cast<int>(b3.to_integer()) << "\n";
+        std::cout << "0x7f_byte: " << static_cast<int>(b4.to_integer()) << "\n";
+        
+        static_assert(b1.to_integer() == 0x00, "Hex literal failed");
+        static_assert(b2.to_integer() == 0xFF, "Hex literal failed");
+        static_assert(b3.to_integer() == 0xAB, "Hex literal failed");
+        static_assert(b4.to_integer() == 0x7f, "Hex literal failed");
+    }
+
+    PrintSubTest("Binary Literals");
+    {
+        constexpr auto b1 = 0b00000000_byte;
+        constexpr auto b2 = 0b11111111_byte;
+        constexpr auto b3 = 0b10101010_byte;
+        constexpr auto b4 = 0b01010101_byte;
+        
+        std::cout << "0b00000000_byte: " << static_cast<int>(b1.to_integer()) << "\n";
+        std::cout << "0b11111111_byte: " << static_cast<int>(b2.to_integer()) << "\n";
+        std::cout << "0b10101010_byte: " << static_cast<int>(b3.to_integer()) << "\n";
+        std::cout << "0b01010101_byte: " << static_cast<int>(b4.to_integer()) << "\n";
+        
+        static_assert(b1.to_integer() == 0b00000000, "Binary literal failed");
+        static_assert(b2.to_integer() == 0b11111111, "Binary literal failed");
+        static_assert(b3.to_integer() == 0b10101010, "Binary literal failed");
+        static_assert(b4.to_integer() == 0b01010101, "Binary literal failed");
+    }
+
+    PrintSubTest("Octal Literals");
+    {
+        constexpr auto b1 = 0_byte;
+        constexpr auto b2 = 0377_byte;  // 255 in octal
+        constexpr auto b3 = 0100_byte;  // 64 in octal
+        constexpr auto b4 = 052_byte;   // 42 in octal
+        
+        std::cout << "0_byte: " << static_cast<int>(b1.to_integer()) << "\n";
+        std::cout << "0377_byte: " << static_cast<int>(b2.to_integer()) << " (255)\n";
+        std::cout << "0100_byte: " << static_cast<int>(b3.to_integer()) << " (64)\n";
+        std::cout << "052_byte: " << static_cast<int>(b4.to_integer()) << " (42)\n";
+        
+        static_assert(b1.to_integer() == 0, "Octal literal failed");
+        static_assert(b2.to_integer() == 255, "Octal literal failed");
+        static_assert(b3.to_integer() == 64, "Octal literal failed");
+        static_assert(b4.to_integer() == 42, "Octal literal failed");
+    }
+
+    PrintSubTest("Literal Usage in Expressions");
+    {
+        constexpr auto result1 = 0xFF_byte & 0xAA_byte;
+        constexpr auto result2 = 0b11110000_byte | 0b00001111_byte;
+        constexpr auto result3 = ~0x00_byte;
+        constexpr auto result4 = 0x0F_byte << 4;
+        
+        static_assert(result1.to_integer() == 0xAA, "Literal expression failed");
+        static_assert(result2.to_integer() == 0xFF, "Literal expression failed");
+        static_assert(result3.to_integer() == 0xFF, "Literal expression failed");
+        static_assert(result4.to_integer() == 0xF0, "Literal expression failed");
+        
+        std::cout << "User-defined literals in expressions verified\n";
+    }
+}
+
+/*!
+ * \brief Test #9: Const Correctness
+ */
+void TestConstCorrectness()
+{
+    PrintTestHeader("Const Correctness");
+
+    PrintSubTest("Const Byte Operations");
+    {
+        const ara::core::Byte cb{123};
+        
+        // All these should work on const Byte
+        [[maybe_unused]] auto val = cb.to_integer();
+        [[maybe_unused]] auto val16 = cb.to_integer<std::uint16_t>();
+        [[maybe_unused]] bool bit3 = cb.test(3);
+        [[maybe_unused]] std::size_t count = cb.count();
+        [[maybe_unused]] bool has_any = cb.any();
+        [[maybe_unused]] bool has_all = cb.all();
+        [[maybe_unused]] bool has_none = cb.none();
+
+        std::cout << "Const byte value: " << static_cast<int>(val) << "\n";
+        std::cout << "Bit 3: " << bit3 << "\n";
+        std::cout << "Bit count: " << count << "\n";
+        
+        assert(val == 123);
+        assert(val16 == 123);
+        assert(bit3 == true);  // 123 = 0b01111011, bit 3 is set
+        assert(count == 6);
+        assert(has_any == true);
+        assert(has_all == false);
+        assert(has_none == false);
+        
+        // These would fail to compile:
+        // cb.set(0);    // Error: cannot call non-const method
+        // cb.reset();   // Error: cannot call non-const method
+        // cb.flip(1);   // Error: cannot call non-const method
+    }
+
+    PrintSubTest("Const in Binary Operations");
+    {
+        const ara::core::Byte ca{0xF0};
+        const ara::core::Byte cb{0x0F};
+        
+        // All binary operations work with const
+        [[maybe_unused]] ara::core::Byte r1 = ca & cb;
+        [[maybe_unused]] ara::core::Byte r2 = ca | cb;
+        [[maybe_unused]] ara::core::Byte r3 = ca ^ cb;
+        [[maybe_unused]] ara::core::Byte r4 = ~ca;
+        [[maybe_unused]] ara::core::Byte r5 = ca << 2;
+        [[maybe_unused]] ara::core::Byte r6 = cb >> 2;
+        
+        assert(r1.to_integer() == 0x00);
+        assert(r2.to_integer() == 0xFF);
+        assert(r3.to_integer() == 0xFF);
+        assert(r4.to_integer() == 0x0F);
+        assert(r5.to_integer() == 0xC0);
+        assert(r6.to_integer() == 0x03);
+        
+        // Comparisons with const
+        [[maybe_unused]] bool eq = (ca == cb);
+        [[maybe_unused]] bool ne = (ca != cb);
+        [[maybe_unused]] bool lt = (ca < cb);
+        [[maybe_unused]] bool gt = (ca > cb);
+        
+        assert(!eq && ne && !lt && gt);
+    }
+
+    PrintSubTest("Constexpr Context");
+    {
+        // Everything should work in constexpr context
+        constexpr ara::core::Byte cb{42};
+        
+        constexpr auto val = cb.to_integer();
+        constexpr bool bit1 = cb.test(1);
+        constexpr auto count = cb.count();
+        constexpr bool any = cb.any();
+        constexpr bool all = cb.all();
+        constexpr bool none = cb.none();
+        
+        static_assert(val == 42, "Constexpr to_integer failed");
+        static_assert(bit1 == true, "Constexpr test failed");  // 42 = 0b00101010
+        static_assert(count == 3, "Constexpr count failed");
+        static_assert(any == true, "Constexpr any failed");
+        static_assert(all == false, "Constexpr all failed");
+        static_assert(none == false, "Constexpr none failed");
+        
+        std::cout << "Constexpr const operations verified\n";
+    }
+}
+
+/*!
+ * \brief Test #10: Edge Cases
+ */
+void TestEdgeCases()
+{
+    PrintTestHeader("Edge Cases");
+
+    PrintSubTest("Zero Byte");
+    {
+        [[maybe_unused]] ara::core::Byte zero{0};
+
+        assert(zero.to_integer() == 0);
+        assert(zero.count() == 0);
+        assert(!zero.any());
+        assert(!zero.all());
+        assert(zero.none());
+        
+        // Operations with zero
+        [[maybe_unused]] ara::core::Byte b{123};
+        assert((b & zero).to_integer() == 0);
+        assert((b | zero).to_integer() == 123);
+        assert((b ^ zero).to_integer() == 123);
+        assert((zero << 5).to_integer() == 0);
+        assert((zero >> 3).to_integer() == 0);
+        
+        std::cout << "Zero byte edge cases passed\n";
+    }
+
+    PrintSubTest("Max Byte (255)");
+    {
+        [[maybe_unused]] ara::core::Byte max{255};
+
+        assert(max.to_integer() == 255);
+        assert(max.count() == 8);
+        assert(max.any());
+        assert(max.all());
+        assert(!max.none());
+        
+        // Operations with max
+        [[maybe_unused]] ara::core::Byte b{123};
+        assert((b & max).to_integer() == 123);
+        assert((b | max).to_integer() == 255);
+        assert((~max).to_integer() == 0);
+        
+        // Shift edge cases
+        assert((max << 8).to_integer() == 255);  // Masked to << 0
+        assert((max >> 8).to_integer() == 255);  // Masked to >> 0
+        
+        std::cout << "Max byte edge cases passed\n";
+    }
+
+    PrintSubTest("Single Bit Patterns");
+    {
+        // Test each single bit position
+        for (std::size_t bit = 0; bit < 8; ++bit) {
+            ara::core::Byte b{static_cast<std::uint8_t>(1u << bit)};
+            
+            assert(b.count() == 1);
+            assert(b.any());
+            assert(!b.all());
+            assert(!b.none());
+            assert(b.test(bit));
+            
+            // Verify only the expected bit is set
+            for (std::size_t i = 0; i < 8; ++i) {
+                assert(b.test(i) == (i == bit));
+            }
+        }
+        std::cout << "Single bit patterns verified\n";
+    }
+
+    PrintSubTest("Alternating Bit Patterns");
+    {
+        [[maybe_unused]] ara::core::Byte pattern1{0b10101010};  // 0xAA
+        [[maybe_unused]] ara::core::Byte pattern2{0b01010101};  // 0x55
+
+        assert(pattern1.count() == 4);
+        assert(pattern2.count() == 4);
+        assert((pattern1 & pattern2).to_integer() == 0);
+        assert((pattern1 | pattern2).to_integer() == 255);
+        assert((pattern1 ^ pattern2).to_integer() == 255);
+        assert(pattern1.to_integer() == (~pattern2).to_integer());
+        
+        std::cout << "Alternating patterns verified\n";
+    }
+}
+
+/*!
+ * \brief Test #11: Type Traits Verification
+ */
+void TestTypeTraits()
+{
+    PrintTestHeader("Type Traits Verification");
+
+    PrintSubTest("Basic Type Properties");
+    {
+        using B = ara::core::Byte;
+        
+        std::cout << "sizeof(Byte): " << sizeof(B) << " bytes\n";
+        std::cout << "alignof(Byte): " << alignof(B) << " bytes\n";
+        
+        assert(sizeof(B) == 1);
+        assert(alignof(B) == 1);
+        
+        // Trivial type checks
+        static_assert(std::is_trivial_v<B>, "Byte must be trivial");
+        static_assert(std::is_trivially_copyable_v<B>, "Byte must be trivially copyable");
+        static_assert(std::is_standard_layout_v<B>, "Byte must have standard layout");
+        static_assert(std::is_pod_v<B>, "Byte must be POD");
+        
+        std::cout << "Byte is a trivial, standard-layout POD type\n";
+    }
+
+    PrintSubTest("Construction and Destruction Traits");
+    {
+        using B = ara::core::Byte;
+        
+        static_assert(std::is_default_constructible_v<B>, "Must be default constructible");
+        static_assert(std::is_trivially_default_constructible_v<B>, "Must be trivially default constructible");
+        static_assert(std::is_nothrow_default_constructible_v<B>, "Must be nothrow default constructible");
+        
+        static_assert(std::is_copy_constructible_v<B>, "Must be copy constructible");
+        static_assert(std::is_trivially_copy_constructible_v<B>, "Must be trivially copy constructible");
+        static_assert(std::is_nothrow_copy_constructible_v<B>, "Must be nothrow copy constructible");
+        
+        static_assert(std::is_move_constructible_v<B>, "Must be move constructible");
+        static_assert(std::is_trivially_move_constructible_v<B>, "Must be trivially move constructible");
+        static_assert(std::is_nothrow_move_constructible_v<B>, "Must be nothrow move constructible");
+        
+        static_assert(std::is_destructible_v<B>, "Must be destructible");
+        static_assert(std::is_trivially_destructible_v<B>, "Must be trivially destructible");
+        static_assert(std::is_nothrow_destructible_v<B>, "Must be nothrow destructible");
+        
+        std::cout << "All construction/destruction traits verified\n";
+    }
+
+    PrintSubTest("Assignment Traits");
+    {
+        using B = ara::core::Byte;
+        
+        static_assert(std::is_copy_assignable_v<B>, "Must be copy assignable");
+        static_assert(std::is_trivially_copy_assignable_v<B>, "Must be trivially copy assignable");
+        static_assert(std::is_nothrow_copy_assignable_v<B>, "Must be nothrow copy assignable");
+        
+        static_assert(std::is_move_assignable_v<B>, "Must be move assignable");
+        static_assert(std::is_trivially_move_assignable_v<B>, "Must be trivially move assignable");
+        static_assert(std::is_nothrow_move_assignable_v<B>, "Must be nothrow move assignable");
+        
+        std::cout << "All assignment traits verified\n";
+    }
+
+    PrintSubTest("Conversion Traits");
+    {
+        using B = ara::core::Byte;
+        
+        // No implicit conversions
+        static_assert(!std::is_convertible_v<int, B>, "No implicit conversion from int");
+        static_assert(!std::is_convertible_v<B, int>, "No implicit conversion to int");
+        static_assert(!std::is_convertible_v<B, bool>, "No implicit conversion to bool");
+        static_assert(!std::is_convertible_v<char, B>, "No implicit conversion from char");
+        static_assert(!std::is_convertible_v<B, char>, "No implicit conversion to char");
+        
+        // But explicit construction is allowed
+        static_assert(std::is_constructible_v<B, int>, "Explicit construction from int allowed");
+        static_assert(std::is_constructible_v<B, char>, "Explicit construction from char allowed");
+        
+        std::cout << "Conversion traits verified (no implicit conversions)\n";
+    }
+
+    PrintSubTest("numeric_limits Specialization");
+    {
+        using B = ara::core::Byte;
+        using limits = std::numeric_limits<B>;
+        
+        std::cout << "numeric_limits<Byte>:\n";
+        std::cout << "  is_specialized: " << limits::is_specialized << "\n";
+        std::cout << "  min(): " << static_cast<int>(limits::min().to_integer()) << "\n";
+        std::cout << "  max(): " << static_cast<int>(limits::max().to_integer()) << "\n";
+        std::cout << "  digits: " << limits::digits << "\n";
+        std::cout << "  is_signed: " << limits::is_signed << "\n";
+        std::cout << "  is_integer: " << limits::is_integer << "\n";
+        
+        assert(limits::is_specialized);
+        assert(limits::min().to_integer() == 0);
+        assert(limits::max().to_integer() == 255);
+        assert(limits::digits == 8);
+        assert(!limits::is_signed);
+        assert(limits::is_integer);
+        
+        std::cout << "numeric_limits specialization verified\n";
+    }
+}
+
+/*!
+ * \brief Test #12: Performance Comparisons
+ */
+void TestPerformanceComparisons()
+{
+    PrintTestHeader("Performance Comparisons");
+
+    constexpr std::size_t iterations = 1'000'000;
+
+    PrintSubTest("Byte vs uint8_t Basic Operations");
+    {
+        // Byte operations
+        PerfTimer timer;
+        ara::core::Byte b1{0xAA};
+        ara::core::Byte b2{0x55};
+        ara::core::Byte result{0};
+        
+        timer.reset();
+        for (std::size_t i = 0; i < iterations; ++i) {
+            result = (b1 & b2) | (~b1 ^ b2);
+            result = result << 1;
+            result = result >> 1;
+        }
+        double byte_time = timer.elapsed();
+        
+        // uint8_t operations
+        std::uint8_t u1 = 0xAA;
+        std::uint8_t u2 = 0x55;
+        std::uint8_t uresult = 0;
+        
+        timer.reset();
+        for (std::size_t i = 0; i < iterations; ++i) {
+            uresult = static_cast<std::uint8_t>((u1 & u2) | (~u1 ^ u2));
+            uresult = static_cast<std::uint8_t>(uresult << 1);
+            uresult = static_cast<std::uint8_t>(uresult >> 1);
+        }
+        double uint8_time = timer.elapsed();
+        
+        std::cout << "Byte operations: " << byte_time << " μs\n";
+        std::cout << "uint8_t operations: " << uint8_time << " μs\n";
+        std::cout << "Overhead: " << ((byte_time / uint8_time) - 1.0) * 100.0 << "%\n";
+        
+        // Prevent optimization
+        volatile auto v1 = result.to_integer();
+        volatile auto v2 = uresult;
+        (void)v1; (void)v2;
+    }
+
+    PrintSubTest("Bit Manipulation Performance");
+    {
+        ara::core::Byte b{0};
+        
+        // Byte bit manipulation
+        PerfTimer timer;
+        timer.reset();
+        for (std::size_t i = 0; i < iterations; ++i) {
+            b.set(i & 7).reset((i + 1) & 7).flip((i + 2) & 7);
+        }
+        double byte_time = timer.elapsed();
+        
+        // Manual bit manipulation
+        std::uint8_t u = 0;
+        timer.reset();
+        for (std::size_t i = 0; i < iterations; ++i) {
+            u = static_cast<std::uint8_t>(u | (1u << (i & 7u)));
+            u = static_cast<std::uint8_t>(u & ~(1u << ((i + 1u) & 7u)));
+            u = static_cast<std::uint8_t>(u ^ (1u << ((i + 2u) & 7u)));
+        }
+        double manual_time = timer.elapsed();
+        
+        std::cout << "Byte bit methods: " << byte_time << " μs\n";
+        std::cout << "Manual bit ops: " << manual_time << " μs\n";
+        std::cout << "Method overhead: " << ((byte_time / manual_time) - 1.0) * 100.0 << "%\n";
+        
+        // Use results to avoid optimization
+        volatile auto v1 = b.to_integer();
+        volatile auto v2 = u;
+        (void)v1; (void)v2;
+    }
+
+    PrintSubTest("Compile-time vs Runtime");
+    {
+        // Compile-time evaluation
+        constexpr auto compile_time_result = []() constexpr {
+            ara::core::Byte b{0xFF};
+            for (int i = 0; i < 100; ++i) {
+                b = ~(b ^ ara::core::Byte{static_cast<std::uint8_t>(i)});
+            }
+            return b.to_integer();
+        }();
+        
+        // Runtime evaluation
+        PerfTimer timer;
+        timer.reset();
+        ara::core::Byte b{0xFF};
+        for (std::size_t iter = 0; iter < iterations; ++iter) {
+            b = ara::core::Byte{0xFF};
+            for (int i = 0; i < 100; ++i) {
+                b = ~(b ^ ara::core::Byte{static_cast<std::uint8_t>(i)});
+            }
+        }
+        double runtime_time = timer.elapsed();
+        
+        std::cout << "Compile-time result: " << static_cast<int>(compile_time_result) << "\n";
+        std::cout << "Runtime result: " << static_cast<int>(b.to_integer()) << "\n";
+        std::cout << "Runtime evaluation: " << runtime_time << " μs for " << iterations << " iterations\n";
+        std::cout << "Compile-time evaluation: 0 μs (computed at compile time)\n";
+        
+        assert(compile_time_result == b.to_integer());
+    }
+
+    std::cout << "\nNote: Performance comparisons show near-zero overhead for ara::core::Byte\n";
+    std::cout << "      The type safety benefits come at virtually no runtime cost.\n";
+}
+
+/**********************************************************************************************************************
+ *  VIOLATION TEST FUNCTIONS (These will terminate the program)
+ *********************************************************************************************************************/
+
+/*!
+ * \brief Test byte range violation (runtime termination)
+ */
+void TestByteRangeViolation()
+{
+    std::cout << "Attempting to create Byte with value 300...\n";
+    [[maybe_unused]] ara::core::Byte b{300};  // This will trigger violation and terminate
+    
+    // Never reached
+    std::cout << "This line should never be printed!\n";
+}
+
+/*!
+ * \brief Test bit position violation (runtime termination)
+ */
+void TestBitPositionViolation()
+{
+    ara::core::Byte b{42};
+    std::cout << "Attempting to test bit 8 (out of range)...\n";
+    [[maybe_unused]] bool bit = b.test(8);  // This will call Abort and terminate
+    
+    // Never reached
+    std::cout << "Bit 8 = " << bit << " (should never print)\n";
+}
+
+/*!
+ * \brief Test shift amount violation (runtime termination)
+ */
+void TestShiftAmountViolation()
+{
+    ara::core::Byte b{1};
+    std::cout << "Attempting to shift by -1 (negative amount)...\n";
+    b <<= -1;  // This will call Abort and terminate
+    
+    // Never reached
+    std::cout << "Result = " << static_cast<int>(b.to_integer()) << " (should never print)\n";
+}
+
+/**********************************************************************************************************************
+ *  NEGATIVE COMPILATION SCENARIOS (All commented out to allow compilation)
+ *********************************************************************************************************************/
+
+void TestNegativeCompilationScenarios()
+{
+    PrintTestHeader("Negative Compilation Scenarios");
+    
+    std::cout << "All negative compilation scenarios are commented out.\n";
+    std::cout << "Uncomment individual sections to observe compilation errors.\n\n";
+
+    // ========================================================================
+    // 1. CONSTRUCTION ERRORS
+    // ========================================================================
+    
+    /*
+    // Test: Construct from non-integral type
+    // Expected: Static assert failure
+    {
+        std::string str = "hello";
+        ara::core::Byte b{str};  // ERROR: Cannot construct from non-integral type
+    }
+    */
+
+    /*
+    // Test: Construct from floating point
+    // Expected: Static assert failure  
+    {
+        ara::core::Byte b{3.14};  // ERROR: Cannot construct from non-integral type
+    }
+    */
+
+    /*
+    // Test: Out-of-range compile-time constant
+    // Expected: Static assert in parse_byte
+    {
+        constexpr ara::core::Byte b{300};  // ERROR: Value exceeds 255
+    }
+    */
+
+    /*
+    // Test: Negative compile-time constant
+    // Expected: Static assert in constructor
+    {
+        constexpr ara::core::Byte b{-1};  // ERROR: Negative value
+    }
+    */
+
+    // ========================================================================
+    // 2. IMPLICIT CONVERSION ERRORS
+    // ========================================================================
+    
+    /*
+    // Test: Implicit conversion from int
+    // Expected: No matching constructor
+    {
+        ara::core::Byte b = 42;  // ERROR: No implicit conversion from int
+    }
+    */
+
+    /*
+    // Test: Implicit conversion to int
+    // Expected: No viable conversion
+    {
+        ara::core::Byte b{42};
+        int x = b;  // ERROR: No implicit conversion to int
+    }
+    */
+
+    /*
+    // Test: Implicit conversion to bool
+    // Expected: Deleted operator bool
+    {
+        ara::core::Byte b{42};
+        if (b) {}  // ERROR: No conversion to bool (deleted)
+    }
+    */
+
+    /*
+    // Test: Function expecting int with Byte argument
+    // Expected: No viable conversion
+    {
+        void takes_int(int x) { (void)x; }
+        ara::core::Byte b{42};
+        takes_int(b);  // ERROR: Cannot convert Byte to int implicitly
+    }
+    */
+
+    // ========================================================================
+    // 3. OPERATOR ERRORS
+    // ========================================================================
+    
+    /*
+    // Test: Arithmetic operations (all deleted)
+    // Expected: Use of deleted function
+    {
+        ara::core::Byte a{10}, b{20};
+        auto sum = a + b;        // ERROR: operator+ is deleted
+        auto diff = a - b;       // ERROR: operator- is deleted  
+        auto prod = a * b;       // ERROR: operator* is deleted
+        auto quot = a / b;       // ERROR: operator/ is deleted
+        auto rem = a % b;        // ERROR: operator% is deleted
+    }
+    */
+
+    /*
+    // Test: Mixed type bitwise operations
+    // Expected: Static assert failure
+    {
+        ara::core::Byte b{0xFF};
+        auto result1 = b & 0xAA;      // ERROR: Cannot AND Byte with int
+        auto result2 = 0xAA & b;      // ERROR: Cannot AND int with Byte
+        auto result3 = b | 0x55;      // ERROR: Cannot OR Byte with int
+        auto result4 = b ^ 0xFF;      // ERROR: Cannot XOR Byte with int
+    }
+    */
+
+    /*
+    // Test: Mixed type comparisons
+    // Expected: Static assert failure
+    {
+        ara::core::Byte b{42};
+        bool eq = (b == 42);      // ERROR: Cannot compare Byte with int
+        bool ne = (42 != b);      // ERROR: Cannot compare int with Byte
+        bool lt = (b < 100);      // ERROR: Cannot compare Byte with int
+    }
+    */
+
+    /*
+    // Test: Shift by non-integral type
+    // Expected: Static assert failure
+    {
+        ara::core::Byte b{1};
+        auto result1 = b << 2.5;     // ERROR: Cannot shift by non-integral
+        auto result2 = b >> "2";     // ERROR: Cannot shift by non-integral
+        b <<= 3.14;                  // ERROR: Cannot shift-assign by non-integral
+    }
+    */
+
+    // ========================================================================
+    // 4. UTILITY FUNCTION ERRORS
+    // ========================================================================
+    
+    /*
+    // Test: to_byte with non-integral type
+    // Expected: Static assert failure
+    {
+        std::string s = "42";
+        auto b = ara::core::to_byte(s);  // ERROR: Cannot convert non-integral to Byte
+    }
+    */
+
+    /*
+    // Test: to_byte with floating point
+    // Expected: Static assert failure
+    {
+        auto b = ara::core::to_byte(3.14);  // ERROR: Cannot convert non-integral to Byte
+    }
+    */
+
+    // ========================================================================
+    // 5. USER-DEFINED LITERAL ERRORS
+    // ========================================================================
+    
+    /*
+    // Test: Invalid decimal literal
+    // Expected: Static assert in parse_byte
+    {
+        using namespace ara::core::literals::byte_literals;
+        constexpr auto b = 256_byte;  // ERROR: Value exceeds 255
+    }
+    */
+
+    /*
+    // Test: Invalid hex literal
+    // Expected: Static assert in parse_byte
+    {
+        using namespace ara::core::literals::byte_literals;
+        constexpr auto b = 0x100_byte;  // ERROR: Value exceeds 255
+    }
+    */
+
+    /*
+    // Test: Invalid binary literal
+    // Expected: Static assert in parse_byte
+    {
+        using namespace ara::core::literals::byte_literals;
+        constexpr auto b = 0b100000000_byte;  // ERROR: Value exceeds 255
+    }
+    */
+
+    /*
+    // Test: Invalid characters in literal
+    // Expected: Static assert in parse_byte
+    {
+        using namespace ara::core::literals::byte_literals;
+        constexpr auto b1 = 12G_byte;    // ERROR: Invalid decimal digit
+        constexpr auto b2 = 0xZZ_byte;   // ERROR: Invalid hex digit
+        constexpr auto b3 = 0b12_byte;   // ERROR: Invalid binary digit
+    }
+    */
+
+    // ========================================================================
+    // 6. CONST CORRECTNESS ERRORS
+    // ========================================================================
+    
+    /*
+    // Test: Modifying const Byte
+    // Expected: No matching member function
+    {
+        const ara::core::Byte cb{42};
+        cb.set(0);     // ERROR: Cannot call non-const method on const object
+        cb.reset();    // ERROR: Cannot call non-const method on const object
+        cb.flip(1);    // ERROR: Cannot call non-const method on const object
+        cb <<= 2;      // ERROR: Cannot modify const object
+    }
+    */
+
+    // ========================================================================
+    // 7. STREAM OPERATOR ERRORS (when enabled)
+    // ========================================================================
+    
+    /*
+    #ifdef ARA_CORE_BYTE_ENABLE_IOSTREAM
+    // Test: Stream operator is not constexpr
+    // Expected: Non-constexpr function call
+    {
+        constexpr auto print_byte = []() {
+            ara::core::Byte b{42};
+            std::cout << b;  // ERROR: operator<< is not constexpr
+            return 0;
+        }();
+    }
+    #endif
+    */
+
+    std::cout << "To test compilation errors:\n";
+    std::cout << "1. Uncomment one section at a time\n";
+    std::cout << "2. Attempt to compile\n";
+    std::cout << "3. Observe the user-friendly error message\n";
+    std::cout << "4. Re-comment the section before testing another\n";
+}


### PR DESCRIPTION
### Motivation / Context  
* Brings the codebase in line with Adaptive AUTOSAR SWS [SWS_CORE_10102-10108].  
* Enables safer low-level APIs (no implicit integral/boolean conversions, explicit range checks).  
* Provides compile-time validated `_byte` literals for hex/dec/oct/bin (C++26-style).  
* Unlocks future features in `ara::core::Array` & friends that depend on the new byte-type.